### PR TITLE
Configure whether to fallback to all endpoints in namespace as last resort

### DIFF
--- a/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -52,7 +52,7 @@ final class HazelcastKubernetesDiscoveryStrategy
                 + "service-name: " + serviceName + ", " //
                 + "service-label: " + serviceLabel + ", " //
                 + "service-label-value: " + serviceLabelValue + ", " //
-                + "namespace: " + namespace //
+                + "namespace: " + namespace + ", " //
                 + "fallback-to-all-in-ns: " + fallbackToAll //
                 + "}");
 

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -28,12 +28,7 @@ import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
 
-import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_SYSTEM_PREFIX;
-import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.NAMESPACE;
-import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.SERVICE_DNS;
-import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_NAME;
-import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_VALUE;
-import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.SERVICE_NAME;
+import static com.noctarius.hazelcast.kubernetes.KubernetesProperties.*;
 
 final class HazelcastKubernetesDiscoveryStrategy
         extends AbstractDiscoveryStrategy {
@@ -50,6 +45,7 @@ final class HazelcastKubernetesDiscoveryStrategy
         String serviceLabel = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_LABEL_NAME);
         String serviceLabelValue = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_LABEL_VALUE, "true");
         String namespace = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, NAMESPACE, getNamespaceOrDefault());
+        Boolean fallbackToAll = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, FALLBACK_TO_ALL, false);
 
         logger.info("Kubernetes Discovery properties: { " //
                 + "service-dns: " + serviceDns + ", " //
@@ -57,13 +53,14 @@ final class HazelcastKubernetesDiscoveryStrategy
                 + "service-label: " + serviceLabel + ", " //
                 + "service-label-value: " + serviceLabelValue + ", " //
                 + "namespace: " + namespace //
+                + "fallback-to-all-in-ns: " + fallbackToAll //
                 + "}");
 
         EndpointResolver endpointResolver;
         if (serviceDns != null) {
             endpointResolver = new DnsEndpointResolver(logger, serviceDns);
         } else {
-            endpointResolver = new ServiceEndpointResolver(logger, serviceName, serviceLabel, serviceLabelValue, namespace);
+            endpointResolver = new ServiceEndpointResolver(logger, serviceName, serviceLabel, serviceLabelValue, namespace, fallbackToAll);
         }
         logger.info("Kubernetes Discovery activated resolver: " + endpointResolver.getClass().getSimpleName());
         this.endpointResolver = endpointResolver;

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
@@ -41,7 +41,8 @@ public class HazelcastKubernetesDiscoveryStrategyFactory
                 KubernetesProperties.SERVICE_NAME, //
                 KubernetesProperties.NAMESPACE, //
                 KubernetesProperties.SERVICE_LABEL_NAME, //
-                KubernetesProperties.SERVICE_LABEL_VALUE));
+                KubernetesProperties.SERVICE_LABEL_VALUE, //
+                KubernetesProperties.FALLBACK_TO_ALL));
     }
 
     public Class<? extends DiscoveryStrategy> getDiscoveryStrategyType() {

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/KubernetesProperties.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/KubernetesProperties.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.config.properties.SimplePropertyDefinition;
 import com.hazelcast.core.TypeConverter;
 
+import static com.hazelcast.config.properties.PropertyTypeConverter.BOOLEAN;
 import static com.hazelcast.config.properties.PropertyTypeConverter.STRING;
 
 /**
@@ -76,6 +77,12 @@ public final class KubernetesProperties {
      * Defines the namespace of the application POD through the Service Discovery REST API of Kubernetes.
      */
     public static final PropertyDefinition NAMESPACE = property("namespace", STRING);
+
+    /**
+     * <p>Configuration key: <tt>fallback-to-all-in-ns</tt></p>
+     * Defines whether when no specific match is found through Kubernetes all endpoints should be probed.
+     */
+    public static final PropertyDefinition FALLBACK_TO_ALL = property("fallback-to-all-in-ns", BOOLEAN);
 
     // Prevent instantiation
     private KubernetesProperties() {

--- a/src/main/java/com/noctarius/hazelcast/kubernetes/ServiceEndpointResolver.java
+++ b/src/main/java/com/noctarius/hazelcast/kubernetes/ServiceEndpointResolver.java
@@ -46,11 +46,12 @@ class ServiceEndpointResolver
     private final String serviceLabel;
     private final String serviceLabelValue;
     private final String namespace;
+    private final boolean fallbackToAll;
 
     private final KubernetesClient client;
 
     public ServiceEndpointResolver(ILogger logger, String serviceName, String serviceLabel, //
-                                   String serviceLabelValue, String namespace) {
+                                   String serviceLabelValue, String namespace, boolean fallbackToAll) {
 
         super(logger);
 
@@ -58,6 +59,7 @@ class ServiceEndpointResolver
         this.namespace = namespace;
         this.serviceLabel = serviceLabel;
         this.serviceLabelValue = serviceLabelValue;
+        this.fallbackToAll = fallbackToAll;
 
         String accountToken = getAccountToken();
         logger.info("Kubernetes Discovery: Bearer Token { " + accountToken + " }");
@@ -76,7 +78,7 @@ class ServiceEndpointResolver
                     client.endpoints().inNamespace(namespace).withLabel(serviceLabel, serviceLabelValue).list());
         }
 
-        return result.isEmpty() ? getNodesByNamespace() : result;
+        return result.isEmpty() && fallbackToAll ? getNodesByNamespace() : result;
     }
 
     private List<DiscoveryNode> getNodesByNamespace() {


### PR DESCRIPTION
Just for reference here is my code change as discussed in https://github.com/noctarius/hazelcast-kubernetes-discovery/issues/16. Feel free to reject it (and then also close the issue).

This was the simplest workaround (albeit a bit hackish) to get the stuff working for us. Eventually we will start using NodeFilter too as suggested (or even better change the architecture so there won't be the need for multiple separate hazelcast clusters).

My point is still that this was a breaking change in behaviour since 0.9.2 and while in most cases discovering all endpoints in namespace is good it might also cause problems and thus you could be a bit more conservative about it. (That is also the reason I've decided to set "fallback-to-all-in-ns" to false). And unfortunately we are also not able to use 0.9.2 anymore (since it doesn't work with hazelcast 3.7.2).