### PR TITLE
OAuth Token Does Not Get Logged

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -54,7 +54,9 @@
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
 
     <!-- Checks that property files contain the same keys.         -->
     <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->

--- a/src/main/java/com/hazelcast/kubernetes/ServiceEndpointResolver.java
+++ b/src/main/java/com/hazelcast/kubernetes/ServiceEndpointResolver.java
@@ -64,13 +64,12 @@ class ServiceEndpointResolver extends HazelcastKubernetesDiscoveryStrategy.Endpo
         this.client = buildKubernetesClient(apiToken, kubernetesMaster);
     }
 
-    private KubernetesClient buildKubernetesClient(String apiToken, String kubernetesMaster) {
-        String oauthToken = apiToken;
-        if (StringUtil.isNullOrEmpty(oauthToken)) {
-            oauthToken = getAccountToken();
+    private KubernetesClient buildKubernetesClient(String token, String kubernetesMaster) {
+        if (StringUtil.isNullOrEmpty(token)) {
+            token = getAccountToken();
         }
-        logger.info("Kubernetes Discovery: Bearer Token { " + oauthToken + " }");
-        Config config = new ConfigBuilder().withOauthToken(oauthToken).withMasterUrl(kubernetesMaster).build();
+        logger.info("Kubernetes Discovery: Bearer Token { " + token + " }");
+        Config config = new ConfigBuilder().withOauthToken(token).withMasterUrl(kubernetesMaster).build();
         return new DefaultKubernetesClient(config);
     }
 

--- a/src/main/java/com/hazelcast/kubernetes/ServiceEndpointResolver.java
+++ b/src/main/java/com/hazelcast/kubernetes/ServiceEndpointResolver.java
@@ -16,22 +16,6 @@
 
 package com.hazelcast.kubernetes;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.nio.Address;
-import com.hazelcast.nio.IOUtil;
-import com.hazelcast.spi.discovery.DiscoveryNode;
-import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
-import com.hazelcast.util.StringUtil;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.fabric8.kubernetes.api.model.EndpointAddress;
-import io.fabric8.kubernetes.api.model.EndpointSubset;
-import io.fabric8.kubernetes.api.model.Endpoints;
-import io.fabric8.kubernetes.api.model.EndpointsList;
-import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.ConfigBuilder;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClient;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -42,8 +26,24 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-class ServiceEndpointResolver
-        extends HazelcastKubernetesDiscoveryStrategy.EndpointResolver {
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.spi.discovery.DiscoveryNode;
+import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
+import com.hazelcast.util.StringUtil;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.fabric8.kubernetes.api.model.EndpointAddress;
+import io.fabric8.kubernetes.api.model.EndpointSubset;
+import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.EndpointsList;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+class ServiceEndpointResolver extends HazelcastKubernetesDiscoveryStrategy.EndpointResolver {
 
     private final String serviceName;
     private final String serviceLabel;
@@ -53,7 +53,7 @@ class ServiceEndpointResolver
     private final KubernetesClient client;
 
     ServiceEndpointResolver(ILogger logger, String serviceName, String serviceLabel, String serviceLabelValue,
-                                   String namespace, String kubernetesMaster, String apiToken) {
+            String namespace, String kubernetesMaster, String apiToken) {
 
         super(logger);
 
@@ -69,11 +69,12 @@ class ServiceEndpointResolver
         if (StringUtil.isNullOrEmpty(oauthToken)) {
             oauthToken = getAccountToken();
         }
-        logger.info("Kubernetes Discovery: Bearer Token { " + apiToken + " }");
+        logger.info("Kubernetes Discovery: Bearer Token { " + oauthToken + " }");
         Config config = new ConfigBuilder().withOauthToken(oauthToken).withMasterUrl(kubernetesMaster).build();
         return new DefaultKubernetesClient(config);
     }
 
+    @Override
     List<DiscoveryNode> resolve() {
         List<DiscoveryNode> result = Collections.emptyList();
         if (serviceName != null && !serviceName.isEmpty()) {


### PR DESCRIPTION
Hi there,

I recently noticed a glitch in com.hazelcast.kubernetes.ServiceEndpointResolver.buildKubernetesClient(String, String): If the provided apiToken is empty, the code does load the token from file correctly but logs the "old" apiToken, which results in a misleading log entry.