### PR TITLE
Document environment variable usage in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,7 +52,9 @@ maven, Gradle, sbt or similar tools, this is as easy as adding it to the build c
 This fragment will add the discovery plugin as well as necessary transitive dependencies into your application classpath. The second step is to configure the discovery plugin inside of your Hazelcast configuration. You have 3 options to configure the plugin:
 
 1. Set a namespace, if no property is set the default namespace will be used: +
-`<property name="namespace">MY-KUBERNETES-NAMESPACE</property>`
+`<property name="namespace">MY-KUBERNETES-NAMESPACE</property>` +
+If you don't want to set the namespace in the XML config file, it is also possible to specify the namespace with the environment variables `KUBERNETES_NAMESPACE` or `OPENSHIFT_BUILD_NAMESPACE`.
+
 
 2. Set a service name to scan all endpoints (pods) connected by a service (the query is combined with the namespace) +
     `<property name="service-name">MY-SERVICE-NAME</property>`


### PR DESCRIPTION
The use of the KUBERNETES_NAMESPACE and OPENSHIFT_BUILD_NAMESPACE
environment variable have not been documented before. One had to look
into the implementation to find out they are supported.