### PR TITLE
Upgrade kubernetes-client to version 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <powermock.version>1.6.6</powermock.version>
 
     <hazelcast.version>3.8.2</hazelcast.version>
-    <kubernetes-client.version>1.4.35</kubernetes-client.version>
+    <kubernetes-client.version>3.0.3</kubernetes-client.version>
     <dnsjava.version>2.1.7</dnsjava.version>
 
     <maven.checkstyle.plugin.version>2.15</maven.checkstyle.plugin.version>

--- a/src/test/java/com/hazelcast/kubernetes/DnsEndpointResolverTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/DnsEndpointResolverTest.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.EndpointSubset;
 import io.fabric8.kubernetes.api.model.Endpoints;
 import io.fabric8.kubernetes.api.model.EndpointsList;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import io.fabric8.kubernetes.client.dsl.ClientMixedOperation;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -65,7 +64,7 @@ public class DnsEndpointResolverTest {
     @Test
     public void testValidServiceDns() throws Exception {
         DnsEndpointResolver endpointResolver = PowerMockito.spy(new DnsEndpointResolver(LOGGER, "hazelcast.com", SERVICE_DNS_TIMEOUT));
-        PowerMockito.when(endpointResolver, MemberMatcher.method(DnsEndpointResolver.class, "buildLookup", null)).withNoArguments().thenReturn(lookup);
+        PowerMockito.when(endpointResolver, MemberMatcher.method(DnsEndpointResolver.class, "buildLookup")).withNoArguments().thenReturn(lookup);
         when(lookup.getResult()).thenReturn(Lookup.SUCCESSFUL);
         when(lookup.run()).thenReturn(getRecords());
         List<DiscoveryNode> nodes = endpointResolver.resolve();
@@ -76,7 +75,7 @@ public class DnsEndpointResolverTest {
     @Test
     public void testDnsFailFlow() throws Exception {
         DnsEndpointResolver endpointResolver = PowerMockito.spy(new DnsEndpointResolver(LOGGER, "hazelcast.com", SERVICE_DNS_TIMEOUT));
-        PowerMockito.when(endpointResolver, MemberMatcher.method(DnsEndpointResolver.class, "buildLookup", null)).withNoArguments().thenReturn(lookup);
+        PowerMockito.when(endpointResolver, MemberMatcher.method(DnsEndpointResolver.class, "buildLookup")).withNoArguments().thenReturn(lookup);
 
         when(lookup.getResult()).thenReturn(Lookup.HOST_NOT_FOUND);
         when(lookup.run()).thenReturn(getRecords());

--- a/src/test/java/com/hazelcast/kubernetes/ServiceEndpointResolverTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/ServiceEndpointResolverTest.java
@@ -9,7 +9,7 @@ import io.fabric8.kubernetes.api.model.EndpointSubset;
 import io.fabric8.kubernetes.api.model.Endpoints;
 import io.fabric8.kubernetes.api.model.EndpointsList;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import io.fabric8.kubernetes.client.dsl.ClientMixedOperation;
+import io.fabric8.kubernetes.client.dsl.base.BaseOperation;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -49,13 +49,13 @@ public class ServiceEndpointResolverTest {
     private DefaultKubernetesClient client;
 
     @Mock
-    private ClientMixedOperation endpoints;
+    private BaseOperation endpoints;
 
     @Mock
-    private ClientMixedOperation inNamespace;
+    private BaseOperation inNamespace;
 
     @Mock
-    private ClientMixedOperation withLabel;
+    private BaseOperation withLabel;
 
     private EndpointsList nodesInNamespace = new EndpointsList();
     private EndpointsList nodesWithLabel = new EndpointsList();


### PR DESCRIPTION
Although the 1.x client works well, it should be beneficial to upgrade to the newest version.
I've run a smoke test successfully on GKE.