### PR TITLE
change is to implement a new Flag "namespace-discovery" in hazelcast-k…

### DIFF
--- a/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -32,6 +32,7 @@ import static com.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_API_TOKEN
 import static com.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_MASTER_URL;
 import static com.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_SYSTEM_PREFIX;
 import static com.hazelcast.kubernetes.KubernetesProperties.NAMESPACE;
+import static com.hazelcast.kubernetes.KubernetesProperties.NAMESPACE_DISCOVERY;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_DNS;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_DNS_TIMEOUT;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_NAME;
@@ -59,6 +60,7 @@ final class HazelcastKubernetesDiscoveryStrategy
         String apiToken = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, KUBERNETES_API_TOKEN, null);
         String namespace = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, NAMESPACE, getNamespaceOrDefault());
         String kubernetesMaster = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, KUBERNETES_MASTER_URL, DEFAULT_MASTER_URL);
+        Boolean namespaceDiscovery = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, NAMESPACE_DISCOVERY, true);
 
         logger.info("Kubernetes Discovery properties: { "
                 + "service-dns: " + serviceDns + ", "
@@ -66,14 +68,16 @@ final class HazelcastKubernetesDiscoveryStrategy
                 + "service-name: " + serviceName + ", "
                 + "service-label: " + serviceLabel + ", "
                 + "service-label-value: " + serviceLabelValue + ", "
-                + "namespace: " + namespace + ", " + "kubernetes-master: " + kubernetesMaster + "}");
+                + "namespace: " + namespace + ", "
+                + "namespace-discovery: " + namespaceDiscovery + ", "
+                + "kubernetes-master: " + kubernetesMaster + "}");
 
         EndpointResolver endpointResolver;
         if (serviceDns != null) {
             endpointResolver = new DnsEndpointResolver(logger, serviceDns, serviceDnsTimeout);
         } else {
             endpointResolver = new ServiceEndpointResolver(logger, serviceName, serviceLabel, serviceLabelValue, namespace,
-                    kubernetesMaster, apiToken);
+                    namespaceDiscovery, kubernetesMaster, apiToken);
         }
         logger.info("Kubernetes Discovery activated resolver: " + endpointResolver.getClass().getSimpleName());
         this.endpointResolver = endpointResolver;

--- a/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
@@ -40,6 +40,7 @@ public class HazelcastKubernetesDiscoveryStrategyFactory
                 KubernetesProperties.SERVICE_DNS,
                 KubernetesProperties.SERVICE_NAME,
                 KubernetesProperties.NAMESPACE,
+                KubernetesProperties.NAMESPACE_DISCOVERY,
                 KubernetesProperties.SERVICE_LABEL_NAME,
                 KubernetesProperties.SERVICE_LABEL_VALUE,
                 KubernetesProperties.KUBERNETES_MASTER_URL,

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.config.properties.SimplePropertyDefinition;
 import com.hazelcast.core.TypeConverter;
 
+import static com.hazelcast.config.properties.PropertyTypeConverter.BOOLEAN;
 import static com.hazelcast.config.properties.PropertyTypeConverter.INTEGER;
 import static com.hazelcast.config.properties.PropertyTypeConverter.STRING;
 
@@ -96,6 +97,12 @@ public final class KubernetesProperties {
      * token from the auto-injected file at: <tt>/var/run/secrets/kubernetes.io/serviceaccount/token</tt>
      */
     public static final PropertyDefinition KUBERNETES_API_TOKEN = property("api-token", STRING);
+
+    /**
+     * <p>Configuration key: <tt>namespace-discovery</tt></p>
+     * Defines the namespace discovery has to be enabled or not. Default will enable the namepsace discovery
+     */
+    public static final PropertyDefinition NAMESPACE_DISCOVERY = property("namespace-discovery", BOOLEAN);
 
     // Prevent instantiation
     private KubernetesProperties() {

--- a/src/test/java/com/hazelcast/kubernetes/KubernetesDiscoveryStrategyFactoryTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/KubernetesDiscoveryStrategyFactoryTest.java
@@ -50,6 +50,7 @@ public class KubernetesDiscoveryStrategyFactoryTest {
         HazelcastKubernetesDiscoveryStrategyFactory factory = new HazelcastKubernetesDiscoveryStrategyFactory();
         Collection<PropertyDefinition> propertyDefinitions = factory.getConfigurationProperties();
         assertTrue(propertyDefinitions.contains(KubernetesProperties.SERVICE_DNS));
+        assertTrue(propertyDefinitions.contains(KubernetesProperties.NAMESPACE_DISCOVERY));
     }
 
     @Test

--- a/src/test/java/com/hazelcast/kubernetes/ServiceEndpointResolverTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/ServiceEndpointResolverTest.java
@@ -44,6 +44,7 @@ public class ServiceEndpointResolverTest {
     private static final String NAMESPACE = "theNamespace";
     private static final String KUBERNETES_MASTER_URL = "http://bla";
     private static final String API_TOKEN = "token";
+    private static final boolean NAMESPACE_DISCOVERY = true;
 
     @Mock
     private DefaultKubernetesClient client;
@@ -73,7 +74,7 @@ public class ServiceEndpointResolverTest {
 
     @Test
     public void resolveWithNamespaceAndNoNodeInNamespace() {
-        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, null, null, NAMESPACE, KUBERNETES_MASTER_URL, API_TOKEN);
+        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, null, null, NAMESPACE, NAMESPACE_DISCOVERY, KUBERNETES_MASTER_URL, API_TOKEN);
         List<DiscoveryNode> nodes = sut.resolve();
 
         assertEquals(0, nodes.size());
@@ -84,7 +85,7 @@ public class ServiceEndpointResolverTest {
         Endpoints discoveryNode = createEndpoints(1);
         nodesInNamespace.getItems().add(discoveryNode);
 
-        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, null, null, NAMESPACE, KUBERNETES_MASTER_URL, API_TOKEN);
+        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, null, null, NAMESPACE, NAMESPACE_DISCOVERY, KUBERNETES_MASTER_URL, API_TOKEN);
         List<DiscoveryNode> nodes = sut.resolve();
 
         assertEquals(1, nodes.size());
@@ -97,7 +98,7 @@ public class ServiceEndpointResolverTest {
         discoveryNode.getSubsets().get(0).setAddresses(null);
         nodesInNamespace.getItems().add(discoveryNode);
 
-        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, null, null, NAMESPACE, KUBERNETES_MASTER_URL, API_TOKEN);
+        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, null, null, NAMESPACE, NAMESPACE_DISCOVERY, KUBERNETES_MASTER_URL, API_TOKEN);
         List<DiscoveryNode> nodes = sut.resolve();
 
         assertEquals(0, nodes.size());
@@ -109,7 +110,7 @@ public class ServiceEndpointResolverTest {
         discoveryNode.setSubsets(null);
         nodesInNamespace.getItems().add(discoveryNode);
 
-        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, null, null, NAMESPACE, KUBERNETES_MASTER_URL, API_TOKEN);
+        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, null, null, NAMESPACE, NAMESPACE_DISCOVERY, KUBERNETES_MASTER_URL, API_TOKEN);
         List<DiscoveryNode> nodes = sut.resolve();
 
         assertEquals(0, nodes.size());
@@ -119,7 +120,7 @@ public class ServiceEndpointResolverTest {
     public void resolveWithServiceLabelAndNodeInNamespace() {
         nodesInNamespace.getItems().add(createEndpoints(1));
 
-        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, SERVICE_LABEL, SERVICE_LABEL_VALUE, NAMESPACE, KUBERNETES_MASTER_URL, API_TOKEN);
+        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, SERVICE_LABEL, SERVICE_LABEL_VALUE, NAMESPACE, NAMESPACE_DISCOVERY, KUBERNETES_MASTER_URL, API_TOKEN);
         List<DiscoveryNode> nodes = sut.resolve();
 
         assertEquals(0, nodes.size());
@@ -131,11 +132,23 @@ public class ServiceEndpointResolverTest {
         Endpoints discoveryNode = createEndpoints(2);
         nodesWithLabel.getItems().add(discoveryNode);
 
-        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, SERVICE_LABEL, SERVICE_LABEL_VALUE, NAMESPACE, KUBERNETES_MASTER_URL, API_TOKEN);
+        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, SERVICE_LABEL, SERVICE_LABEL_VALUE, NAMESPACE, NAMESPACE_DISCOVERY, KUBERNETES_MASTER_URL, API_TOKEN);
         List<DiscoveryNode> nodes = sut.resolve();
 
         assertEquals(1, nodes.size());
         assertEquals(2, nodes.get(0).getPrivateAddress().getPort());
+    }
+
+    @Test
+    public void resolveWithoutNamespaceDiscovery() {
+        Endpoints discoveryNode = createEndpoints(1);
+        nodesInNamespace.getItems().add(discoveryNode);
+
+        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, null, null, NAMESPACE, false, KUBERNETES_MASTER_URL, API_TOKEN);
+        List<DiscoveryNode> nodes = sut.resolve();
+
+        assertEquals(0, nodes.size());
+
     }
 
     @Test


### PR DESCRIPTION
change is to implement a new flag "namespace-discovery" in hazelcast-kubernetes properties to discover nodes at service level only. We have different applications that has been hosted on same namespace in Openshit and it is resulting in discovering the different applications. We wanted to skip this behaviour of hazelcast discovering the namespace with a flag. The property "namespace-discovery" defaults to true and will not skip any of thr discovery unless it has been made false in hazelcast.xml.