### PR TITLE
Adding service port configuration support

### DIFF
--- a/src/main/java/com/hazelcast/kubernetes/DnsEndpointResolver.java
+++ b/src/main/java/com/hazelcast/kubernetes/DnsEndpointResolver.java
@@ -41,10 +41,12 @@ final class DnsEndpointResolver
 
     private final String serviceDns;
     private final int serviceDnsTimeout;
+    private final int port;
 
-    DnsEndpointResolver(ILogger logger, String serviceDns, int serviceDnsTimeout) {
+    DnsEndpointResolver(ILogger logger, String serviceDns, int port, int serviceDnsTimeout) {
         super(logger);
         this.serviceDns = serviceDns;
+        this.port = port;
         this.serviceDnsTimeout = serviceDnsTimeout;
     }
 
@@ -74,7 +76,7 @@ final class DnsEndpointResolver
                 //      Address: 10.1.9.33
                 SRVRecord srv = (SRVRecord) record;
                 InetAddress[] inetAddress = getAllAddresses(srv);
-                int port = getHazelcastPort(srv.getPort());
+                int port = (this.port > 0) ? this.port : getHazelcastPort(srv.getPort());
 
                 for (InetAddress i : inetAddress) {
                     Address address = new Address(i, port);

--- a/src/main/java/com/hazelcast/kubernetes/DnsEndpointResolver.java
+++ b/src/main/java/com/hazelcast/kubernetes/DnsEndpointResolver.java
@@ -77,7 +77,9 @@ final class DnsEndpointResolver
                 SRVRecord srv = (SRVRecord) record;
                 InetAddress[] inetAddress = getAllAddresses(srv);
                 int port = (this.port > 0) ? this.port : getHazelcastPort(srv.getPort());
-
+                if (logger.isFineEnabled()) {
+                    logger.fine("DNS record target: " + srv.getTarget() + " port: " + port);
+                }
                 for (InetAddress i : inetAddress) {
                     Address address = new Address(i, port);
 

--- a/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -37,6 +37,7 @@ import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_DNS_TIMEOUT;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_NAME;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_VALUE;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_NAME;
+import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_PORT;
 import static com.hazelcast.kubernetes.KubernetesProperties.RESOLVE_NOT_READY_ADDRESSES;
 
 final class HazelcastKubernetesDiscoveryStrategy
@@ -55,6 +56,7 @@ final class HazelcastKubernetesDiscoveryStrategy
         int serviceDnsTimeout
                 = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_DNS_TIMEOUT, DEFAULT_SERVICE_DNS_TIMEOUT_SECONDS);
         String serviceName = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_NAME);
+        int port = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_PORT, 0);
         String serviceLabel = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_LABEL_NAME);
         String serviceLabelValue = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_LABEL_VALUE, "true");
         String namespace = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, NAMESPACE, getNamespaceOrDefault());
@@ -66,6 +68,7 @@ final class HazelcastKubernetesDiscoveryStrategy
                 + "service-dns: " + serviceDns + ", "
                 + "service-dns-timeout: " + serviceDnsTimeout + ", "
                 + "service-name: " + serviceName + ", "
+                + "service-port: " + port + ", "
                 + "service-label: " + serviceLabel + ", "
                 + "service-label-value: " + serviceLabelValue + ", "
                 + "namespace: " + namespace + ", "
@@ -74,9 +77,9 @@ final class HazelcastKubernetesDiscoveryStrategy
 
         EndpointResolver endpointResolver;
         if (serviceDns != null) {
-            endpointResolver = new DnsEndpointResolver(logger, serviceDns, serviceDnsTimeout);
+            endpointResolver = new DnsEndpointResolver(logger, serviceDns, port, serviceDnsTimeout);
         } else {
-            endpointResolver = new ServiceEndpointResolver(logger, serviceName, serviceLabel, serviceLabelValue,
+            endpointResolver = new ServiceEndpointResolver(logger, serviceName, port, serviceLabel, serviceLabelValue,
                     namespace, resolveNotReadyAddresses, kubernetesMaster, apiToken);
         }
         logger.info("Kubernetes Discovery activated resolver: " + endpointResolver.getClass().getSimpleName());

--- a/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
@@ -39,6 +39,7 @@ public class HazelcastKubernetesDiscoveryStrategyFactory
         PROPERTY_DEFINITIONS = Collections.unmodifiableCollection(Arrays.asList(
                 KubernetesProperties.SERVICE_DNS,
                 KubernetesProperties.SERVICE_NAME,
+                KubernetesProperties.SERVICE_PORT,
                 KubernetesProperties.SERVICE_LABEL_NAME,
                 KubernetesProperties.SERVICE_LABEL_VALUE,
                 KubernetesProperties.NAMESPACE,

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
@@ -105,8 +105,8 @@ public final class KubernetesProperties {
     public static final PropertyDefinition KUBERNETES_API_TOKEN = property("api-token", STRING);
 
     /**
-     * <p>Configuration key: <tt>hazelcast-service-port</tt></p>
-     * If specified, its value defines the endpoint port of the service (overriding the default).
+     * <p>Configuration key: <tt>service-port</tt></p>
+     * If specified with a value greater than 0, its value defines the endpoint port of the service (overriding the default).
      */
     public static final PropertyDefinition SERVICE_PORT = property("service-port", INTEGER);
 

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
@@ -104,6 +104,12 @@ public final class KubernetesProperties {
      */
     public static final PropertyDefinition KUBERNETES_API_TOKEN = property("api-token", STRING);
 
+    /**
+     * <p>Configuration key: <tt>hazelcast-service-port</tt></p>
+     * If specified, its value defines the endpoint port of the service (overriding the default).
+     */
+    public static final PropertyDefinition SERVICE_PORT = property("service-port", INTEGER);
+
     // Prevent instantiation
     private KubernetesProperties() {
     }

--- a/src/main/java/com/hazelcast/kubernetes/ServiceEndpointResolver.java
+++ b/src/main/java/com/hazelcast/kubernetes/ServiceEndpointResolver.java
@@ -50,15 +50,16 @@ class ServiceEndpointResolver extends HazelcastKubernetesDiscoveryStrategy.Endpo
     private final String serviceLabelValue;
     private final String namespace;
     private final Boolean resolveNotReadyAddresses;
-
+    private final int port;
     private final KubernetesClient client;
 
-    ServiceEndpointResolver(ILogger logger, String serviceName, String serviceLabel, String serviceLabelValue,
+    ServiceEndpointResolver(ILogger logger, String serviceName, int port, String serviceLabel, String serviceLabelValue,
                             String namespace, Boolean resolveNotReadyAddresses, String kubernetesMaster, String apiToken) {
 
         super(logger);
 
         this.serviceName = serviceName;
+        this.port = port;
         this.namespace = namespace;
         this.serviceLabel = serviceLabel;
         this.serviceLabelValue = serviceLabelValue;
@@ -142,7 +143,8 @@ class ServiceEndpointResolver extends HazelcastKubernetesDiscoveryStrategy.Endpo
         Map<String, Object> properties = endpointAddress.getAdditionalProperties();
         String ip = endpointAddress.getIp();
         InetAddress inetAddress = mapAddress(ip);
-        int port = getServicePort(properties);
+        int port = (this.port > 0) ? this.port : getServicePort(properties);
+        logger.fine("Discovered node: " + ip + " port: " + port);
         Address address = new Address(inetAddress, port);
         discoveredNodes.add(new SimpleDiscoveryNode(address, properties));
     }

--- a/src/main/java/com/hazelcast/kubernetes/ServiceEndpointResolver.java
+++ b/src/main/java/com/hazelcast/kubernetes/ServiceEndpointResolver.java
@@ -144,7 +144,9 @@ class ServiceEndpointResolver extends HazelcastKubernetesDiscoveryStrategy.Endpo
         String ip = endpointAddress.getIp();
         InetAddress inetAddress = mapAddress(ip);
         int port = (this.port > 0) ? this.port : getServicePort(properties);
-        logger.fine("Discovered node: " + ip + " port: " + port);
+        if (logger.isFineEnabled()) {
+            logger.fine("Discovered node: " + ip + " port: " + port);
+        }
         Address address = new Address(inetAddress, port);
         discoveredNodes.add(new SimpleDiscoveryNode(address, properties));
     }

--- a/src/test/java/com/hazelcast/kubernetes/DnsEndpointResolverTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/DnsEndpointResolverTest.java
@@ -56,25 +56,35 @@ public class DnsEndpointResolverTest {
 
     @Test
     public void testInvalidServiceDns() {
-        DnsEndpointResolver endpointResolver = new DnsEndpointResolver(LOGGER, "http://test", SERVICE_DNS_TIMEOUT);
+        DnsEndpointResolver endpointResolver = new DnsEndpointResolver(LOGGER, "http://test", 0, SERVICE_DNS_TIMEOUT);
         List<DiscoveryNode> nodes = endpointResolver.resolve();
         assertTrue(nodes.isEmpty());
     }
 
     @Test
     public void testValidServiceDns() throws Exception {
-        DnsEndpointResolver endpointResolver = PowerMockito.spy(new DnsEndpointResolver(LOGGER, "hazelcast.com", SERVICE_DNS_TIMEOUT));
+        testValidServiceDns(0, 5701);
+    }
+
+    @Test
+    public void testValidServiceDnsWithCustomPort() throws Exception {
+        testValidServiceDns(333, 333);
+    }
+
+    private void testValidServiceDns(final int port, final int expectedPort) throws Exception {
+        DnsEndpointResolver endpointResolver = PowerMockito.spy(new DnsEndpointResolver(LOGGER, "hazelcast.com", port, SERVICE_DNS_TIMEOUT));
         PowerMockito.when(endpointResolver, MemberMatcher.method(DnsEndpointResolver.class, "buildLookup")).withNoArguments().thenReturn(lookup);
         when(lookup.getResult()).thenReturn(Lookup.SUCCESSFUL);
         when(lookup.run()).thenReturn(getRecords());
         List<DiscoveryNode> nodes = endpointResolver.resolve();
         assertEquals(1, nodes.size());
         assertEquals("127.0.0.1", nodes.get(0).getPrivateAddress().getHost());
+        assertEquals(expectedPort, nodes.get(0).getPrivateAddress().getPort());
     }
 
     @Test
     public void testDnsFailFlow() throws Exception {
-        DnsEndpointResolver endpointResolver = PowerMockito.spy(new DnsEndpointResolver(LOGGER, "hazelcast.com", SERVICE_DNS_TIMEOUT));
+        DnsEndpointResolver endpointResolver = PowerMockito.spy(new DnsEndpointResolver(LOGGER, "hazelcast.com", 0, SERVICE_DNS_TIMEOUT));
         PowerMockito.when(endpointResolver, MemberMatcher.method(DnsEndpointResolver.class, "buildLookup")).withNoArguments().thenReturn(lookup);
 
         when(lookup.getResult()).thenReturn(Lookup.HOST_NOT_FOUND);

--- a/src/test/java/com/hazelcast/kubernetes/KubernetesDiscoveryStrategyFactoryTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/KubernetesDiscoveryStrategyFactoryTest.java
@@ -50,12 +50,14 @@ public class KubernetesDiscoveryStrategyFactoryTest {
         HazelcastKubernetesDiscoveryStrategyFactory factory = new HazelcastKubernetesDiscoveryStrategyFactory();
         Collection<PropertyDefinition> propertyDefinitions = factory.getConfigurationProperties();
         assertTrue(propertyDefinitions.contains(KubernetesProperties.SERVICE_DNS));
+        assertTrue(propertyDefinitions.contains(KubernetesProperties.SERVICE_PORT));
     }
 
     @Test
     public void createDiscoveryStrategy() {
         HashMap<String, Comparable> properties = new HashMap<String, Comparable>();
         properties.put(KubernetesProperties.KUBERNETES_API_TOKEN.key(), API_TOKEN);
+        properties.put(String.valueOf(KubernetesProperties.SERVICE_PORT), 333);
         HazelcastKubernetesDiscoveryStrategyFactory factory = new HazelcastKubernetesDiscoveryStrategyFactory();
         DiscoveryStrategy strategy   = factory.newDiscoveryStrategy(discoveryNode, LOGGER, properties);
         assertTrue(strategy instanceof  HazelcastKubernetesDiscoveryStrategy);

--- a/src/test/java/com/hazelcast/kubernetes/ServiceEndpointResolverTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/ServiceEndpointResolverTest.java
@@ -81,7 +81,7 @@ public class ServiceEndpointResolverTest {
 
     @Test
     public void resolveWithNamespaceAndNodeInNamespace() {
-        resolveWithNamespaceAndNodeInNamespace(0, 1);
+        resolveWithNamespaceAndNodeInNamespace(0, 1); // expected port 1 is the kubernetes discovery endpoint port
     }
 
     @Test

--- a/src/test/java/com/hazelcast/kubernetes/ServiceEndpointResolverTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/ServiceEndpointResolverTest.java
@@ -73,7 +73,7 @@ public class ServiceEndpointResolverTest {
 
     @Test
     public void resolveWithNamespaceAndNoNodeInNamespace() {
-        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, null, null, NAMESPACE, null, KUBERNETES_MASTER_URL, API_TOKEN);
+        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, 0, null, null, NAMESPACE, null, KUBERNETES_MASTER_URL, API_TOKEN);
         List<DiscoveryNode> nodes = sut.resolve();
 
         assertEquals(0, nodes.size());
@@ -81,14 +81,23 @@ public class ServiceEndpointResolverTest {
 
     @Test
     public void resolveWithNamespaceAndNodeInNamespace() {
+        resolveWithNamespaceAndNodeInNamespace(0, 1);
+    }
+
+    @Test
+    public void resolveWithNamespaceAndNodeInNamespaceAndCustomPort() {
+        resolveWithNamespaceAndNodeInNamespace(333, 333);
+    }
+
+    private void resolveWithNamespaceAndNodeInNamespace(final int port, final int expectedPort) {
         Endpoints discoveryNode = createEndpoints(1);
         nodesInNamespace.getItems().add(discoveryNode);
 
-        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, null, null, NAMESPACE, null, KUBERNETES_MASTER_URL, API_TOKEN);
+        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, port, null, null, NAMESPACE, null, KUBERNETES_MASTER_URL, API_TOKEN);
         List<DiscoveryNode> nodes = sut.resolve();
 
         assertEquals(1, nodes.size());
-        assertEquals(1, nodes.get(0).getPrivateAddress().getPort());
+        assertEquals(expectedPort, nodes.get(0).getPrivateAddress().getPort());
     }
 
     @Test
@@ -97,7 +106,7 @@ public class ServiceEndpointResolverTest {
         discoveryNode.getSubsets().get(0).setAddresses(null);
         nodesInNamespace.getItems().add(discoveryNode);
 
-        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, null, null, NAMESPACE, null, KUBERNETES_MASTER_URL, API_TOKEN);
+        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, 0, null, null, NAMESPACE, null, KUBERNETES_MASTER_URL, API_TOKEN);
         List<DiscoveryNode> nodes = sut.resolve();
 
         assertEquals(0, nodes.size());
@@ -109,7 +118,7 @@ public class ServiceEndpointResolverTest {
         discoveryNode.setSubsets(null);
         nodesInNamespace.getItems().add(discoveryNode);
 
-        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, null, null, NAMESPACE, null, KUBERNETES_MASTER_URL, API_TOKEN);
+        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, 0, null, null, NAMESPACE, null, KUBERNETES_MASTER_URL, API_TOKEN);
         List<DiscoveryNode> nodes = sut.resolve();
 
         assertEquals(0, nodes.size());
@@ -119,7 +128,7 @@ public class ServiceEndpointResolverTest {
     public void resolveWithServiceLabelAndNodeInNamespace() {
         nodesInNamespace.getItems().add(createEndpoints(1));
 
-        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, SERVICE_LABEL, SERVICE_LABEL_VALUE, NAMESPACE, null, KUBERNETES_MASTER_URL, API_TOKEN);
+        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, 0, SERVICE_LABEL, SERVICE_LABEL_VALUE, NAMESPACE, null, KUBERNETES_MASTER_URL, API_TOKEN);
         List<DiscoveryNode> nodes = sut.resolve();
 
         assertEquals(0, nodes.size());
@@ -131,7 +140,7 @@ public class ServiceEndpointResolverTest {
         Endpoints discoveryNode = createEndpoints(2);
         nodesWithLabel.getItems().add(discoveryNode);
 
-        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, SERVICE_LABEL, SERVICE_LABEL_VALUE, NAMESPACE, null, KUBERNETES_MASTER_URL, API_TOKEN);
+        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, 0, SERVICE_LABEL, SERVICE_LABEL_VALUE, NAMESPACE, null, KUBERNETES_MASTER_URL, API_TOKEN);
         List<DiscoveryNode> nodes = sut.resolve();
 
         assertEquals(1, nodes.size());
@@ -143,7 +152,7 @@ public class ServiceEndpointResolverTest {
         nodesInNamespace.getItems().add(createEndpoints(1));
         nodesInNamespace.getItems().add(createNotReadyEndpoints(2));
 
-        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, null, null, NAMESPACE, RESOLVE_NOT_READY_ADDRESSES, KUBERNETES_MASTER_URL, API_TOKEN);
+        ServiceEndpointResolver sut = new ServiceEndpointResolver(LOGGER, SERVICE_NAME, 0, null, null, NAMESPACE, RESOLVE_NOT_READY_ADDRESSES, KUBERNETES_MASTER_URL, API_TOKEN);
         List<DiscoveryNode> nodes = sut.resolve();
 
         assertEquals(2, nodes.size());


### PR DESCRIPTION
Adding new plugin property "service-port". This is solution for issue #40 allowing to override the default port. The property is used in both DNS and REST resolver.