### PR TITLE
Add retries to REST calls to Kubernetes API

### DIFF
--- a/src/main/java/com/hazelcast/kubernetes/DefaultKubernetesClient.java
+++ b/src/main/java/com/hazelcast/kubernetes/DefaultKubernetesClient.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.kubernetes;
+
+import com.eclipsesource.json.Json;
+import com.eclipsesource.json.JsonArray;
+import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
+import com.hazelcast.nio.IOUtil;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.Set;
+
+/**
+ * Responsible for connecting to the Kubernetes API.
+ * <p>
+ * Note: This client should always be used from inside Kubernetes since it depends on the CA Cert file, which exists
+ * in the POD filesystem.
+ *
+ * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/">Kubernetes API</a>
+ */
+class DefaultKubernetesClient
+        implements KubernetesClient {
+    private static final int HTTP_OK = 200;
+
+    private final String kubernetesMaster;
+    private final String apiToken;
+
+    DefaultKubernetesClient(String kubernetesMaster, String apiToken) {
+        this.kubernetesMaster = kubernetesMaster;
+        this.apiToken = apiToken;
+    }
+
+    @Override
+    public Endpoints endpoints(String namespace) {
+        String urlString = String.format("%s/api/v1/namespaces/%s/endpoints", kubernetesMaster, namespace);
+        return parseEndpointsList(callGet(urlString));
+
+    }
+
+    @Override
+    public Endpoints endpointsByLabel(String namespace, String serviceLabel, String serviceLabelValue) {
+        String param = String.format("labelSelector=%s=%s", serviceLabel, serviceLabelValue);
+        String urlString = String.format("%s/api/v1/namespaces/%s/endpoints?%s", kubernetesMaster, namespace, param);
+        return parseEndpointsList(callGet(urlString));
+    }
+
+    @Override
+    public Endpoints endpointsByName(String namespace, String endpointName) {
+        String urlString = String.format("%s/api/v1/namespaces/%s/endpoints/%s", kubernetesMaster, namespace, endpointName);
+        JsonObject json = callGet(urlString);
+        return parseEndpoint(json);
+    }
+
+    private JsonObject callGet(String urlString) {
+        HttpURLConnection connection = null;
+        try {
+            URL url = new URL(urlString);
+            connection = (HttpURLConnection) url.openConnection();
+            if (connection instanceof HttpsURLConnection) {
+                ((HttpsURLConnection) connection).setSSLSocketFactory(buildSslSocketFactory());
+            }
+            connection.setRequestMethod("GET");
+            connection.setRequestProperty("Authorization", String.format("Bearer %s", apiToken));
+
+            if (connection.getResponseCode() != HTTP_OK) {
+                throw new KubernetesClientException(String.format("Failure executing: GET at: %s. Message: %s,", urlString,
+                        read(connection.getErrorStream())));
+            }
+            return Json.parse(read(connection.getInputStream())).asObject();
+        } catch (Exception e) {
+            throw new KubernetesClientException("Failure in KubernetesClient", e);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    private static String read(InputStream stream) {
+        Scanner scanner = new Scanner(stream, "UTF-8");
+        scanner.useDelimiter("\\Z");
+        return scanner.next();
+    }
+
+    private static Endpoints parseEndpointsList(JsonObject json) {
+        List<EntrypointAddress> addresses = new ArrayList<EntrypointAddress>();
+        List<EntrypointAddress> notReadyAddresses = new ArrayList<EntrypointAddress>();
+
+        for (JsonValue object : toJsonArray(json.get("items"))) {
+            Endpoints endpoints = parseEndpoint(object);
+            addresses.addAll(endpoints.getAddresses());
+            notReadyAddresses.addAll(endpoints.getNotReadyAddresses());
+        }
+
+        return new Endpoints(addresses, notReadyAddresses);
+    }
+
+    private static Endpoints parseEndpoint(JsonValue endpointsJson) {
+        List<EntrypointAddress> addresses = new ArrayList<EntrypointAddress>();
+        List<EntrypointAddress> notReadyAddresses = new ArrayList<EntrypointAddress>();
+
+        for (JsonValue subset : toJsonArray(endpointsJson.asObject().get("subsets"))) {
+            for (JsonValue address : toJsonArray(subset.asObject().get("addresses"))) {
+                addresses.add(parseEntrypointAddress(address));
+            }
+            for (JsonValue notReadyAddress : toJsonArray(subset.asObject().get("notReadyAddresses"))) {
+                notReadyAddresses.add(parseEntrypointAddress(notReadyAddress));
+            }
+        }
+        return new Endpoints(addresses, notReadyAddresses);
+    }
+
+    private static EntrypointAddress parseEntrypointAddress(JsonValue endpointAddressJson) {
+        String ip = endpointAddressJson.asObject().get("ip").asString();
+        Map<String, Object> additionalProperties = parseAdditionalProperties(endpointAddressJson);
+        return new EntrypointAddress(ip, additionalProperties);
+    }
+
+    private static Map<String, Object> parseAdditionalProperties(JsonValue endpointAddressJson) {
+        Set<String> knownFieldNames = new HashSet<String>(Arrays.asList("ip", "nodeName", "targetRef", "hostname"));
+
+        Map<String, Object> result = new HashMap<String, Object>();
+        Iterator<JsonObject.Member> iter = endpointAddressJson.asObject().iterator();
+        while (iter.hasNext()) {
+            JsonObject.Member member = iter.next();
+            if (!knownFieldNames.contains(member.getName())) {
+                result.put(member.getName(), toString(member.getValue()));
+            }
+        }
+        return result;
+    }
+
+    private static JsonArray toJsonArray(JsonValue jsonValue) {
+        if (jsonValue == null || jsonValue.isNull()) {
+            return new JsonArray();
+        } else {
+            return jsonValue.asArray();
+        }
+    }
+
+    private static String toString(JsonValue jsonValue) {
+        if (jsonValue.isString()) {
+            return jsonValue.asString();
+        } else {
+            return jsonValue.toString();
+        }
+    }
+
+    /**
+     * Builds SSL Socket Factory with the public CA Certificate from Kubernetes Master.
+     */
+    private static SSLSocketFactory buildSslSocketFactory() {
+        try {
+            KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            keyStore.load(null, null);
+            keyStore.setCertificateEntry("ca", generateCertificate());
+
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            tmf.init(keyStore);
+
+            SSLContext context = SSLContext.getInstance("TLS");
+            context.init(null, tmf.getTrustManagers(), null);
+            return context.getSocketFactory();
+
+        } catch (Exception e) {
+            throw new KubernetesClientException("Failure in generating SSLSocketFactory", e);
+        }
+    }
+
+    /**
+     * Generates CA Certificate from the default CA Cert file (which always exists in the Kubernetes POD).
+     */
+    private static Certificate generateCertificate()
+            throws IOException, CertificateException {
+        InputStream caInput = null;
+        try {
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            caInput = new BufferedInputStream(new FileInputStream(new File(caCertPath())));
+            return cf.generateCertificate(caInput);
+        } finally {
+            IOUtil.closeResource(caInput);
+        }
+    }
+
+    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
+    private static String caCertPath() {
+        return "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
+    }
+
+}

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -16,56 +16,13 @@
 
 package com.hazelcast.kubernetes;
 
-import com.eclipsesource.json.Json;
-import com.eclipsesource.json.JsonArray;
-import com.eclipsesource.json.JsonObject;
-import com.eclipsesource.json.JsonValue;
-import com.hazelcast.nio.IOUtil;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManagerFactory;
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.security.KeyStore;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Scanner;
-import java.util.Set;
 
 /**
  * Responsible for connecting to the Kubernetes API.
- * <p>
- * Note: This client should always be used from inside Kubernetes since it depends on the CA Cert file, which exists
- * in the POD filesystem.
- *
- * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/">Kubernetes API</a>
  */
-class KubernetesClient {
-    private static final int HTTP_OK = 200;
-
-    private final String kubernetesMaster;
-    private final String apiToken;
-
-    KubernetesClient(String kubernetesMaster, String apiToken) {
-        this.kubernetesMaster = kubernetesMaster;
-        this.apiToken = apiToken;
-    }
+interface KubernetesClient {
 
     /**
      * Retrieves POD addresses for all services in the given {@code namespace}.
@@ -74,11 +31,7 @@ class KubernetesClient {
      * @return all POD addresses from the given {@code namespace}
      * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#list-143">Kubernetes Endpoint API</a>
      */
-    Endpoints endpoints(String namespace) {
-        String urlString = String.format("%s/api/v1/namespaces/%s/endpoints", kubernetesMaster, namespace);
-        return parseEndpointsList(callGet(urlString));
-
-    }
+    Endpoints endpoints(String namespace);
 
     /**
      * Retrieves POD addresses for all services in the given {@code namespace} filtered by {@code serviceLabel}
@@ -90,11 +43,7 @@ class KubernetesClient {
      * @return all POD addresses from the given {@code namespace} filtered by the label
      * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#list-143">Kubernetes Endpoint API</a>
      */
-    Endpoints endpointsByLabel(String namespace, String serviceLabel, String serviceLabelValue) {
-        String param = String.format("labelSelector=%s=%s", serviceLabel, serviceLabelValue);
-        String urlString = String.format("%s/api/v1/namespaces/%s/endpoints?%s", kubernetesMaster, namespace, param);
-        return parseEndpointsList(callGet(urlString));
-    }
+    Endpoints endpointsByLabel(String namespace, String serviceLabel, String serviceLabelValue);
 
     /**
      * Retrieves POD addresses from the given {@code namespace} and the given {@code endpointName}.
@@ -104,152 +53,12 @@ class KubernetesClient {
      * @return all POD addresses from the given {@code namespace} and the given {@code endpointName}
      * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#list-143">Kubernetes Endpoint API</a>
      */
-    Endpoints endpointsByName(String namespace, String endpointName) {
-        String urlString = String.format("%s/api/v1/namespaces/%s/endpoints/%s", kubernetesMaster, namespace, endpointName);
-        JsonObject json = callGet(urlString);
-        return parseEndpoint(json);
-    }
-
-    private JsonObject callGet(String urlString) {
-        HttpURLConnection connection = null;
-        try {
-            URL url = new URL(urlString);
-            connection = (HttpURLConnection) url.openConnection();
-            if (connection instanceof HttpsURLConnection) {
-                ((HttpsURLConnection) connection).setSSLSocketFactory(buildSslSocketFactory());
-            }
-            connection.setRequestMethod("GET");
-            connection.setRequestProperty("Authorization", String.format("Bearer %s", apiToken));
-
-            if (connection.getResponseCode() != HTTP_OK) {
-                throw new KubernetesClientException(String.format("Failure executing: GET at: %s. Message: %s,", urlString,
-                        read(connection.getErrorStream())));
-            }
-            return Json.parse(read(connection.getInputStream())).asObject();
-        } catch (Exception e) {
-            throw new KubernetesClientException("Failure in KubernetesClient", e);
-        } finally {
-            if (connection != null) {
-                connection.disconnect();
-            }
-        }
-    }
-
-    private static String read(InputStream stream) {
-        Scanner scanner = new Scanner(stream, "UTF-8");
-        scanner.useDelimiter("\\Z");
-        return scanner.next();
-    }
-
-    private static Endpoints parseEndpointsList(JsonObject json) {
-        List<EntrypointAddress> addresses = new ArrayList<EntrypointAddress>();
-        List<EntrypointAddress> notReadyAddresses = new ArrayList<EntrypointAddress>();
-
-        for (JsonValue object : toJsonArray(json.get("items"))) {
-            Endpoints endpoints = parseEndpoint(object);
-            addresses.addAll(endpoints.getAddresses());
-            notReadyAddresses.addAll(endpoints.getNotReadyAddresses());
-        }
-
-        return new Endpoints(addresses, notReadyAddresses);
-    }
-
-    private static Endpoints parseEndpoint(JsonValue endpointsJson) {
-        List<EntrypointAddress> addresses = new ArrayList<EntrypointAddress>();
-        List<EntrypointAddress> notReadyAddresses = new ArrayList<EntrypointAddress>();
-
-        for (JsonValue subset : toJsonArray(endpointsJson.asObject().get("subsets"))) {
-            for (JsonValue address : toJsonArray(subset.asObject().get("addresses"))) {
-                addresses.add(parseEntrypointAddress(address));
-            }
-            for (JsonValue notReadyAddress : toJsonArray(subset.asObject().get("notReadyAddresses"))) {
-                notReadyAddresses.add(parseEntrypointAddress(notReadyAddress));
-            }
-        }
-        return new Endpoints(addresses, notReadyAddresses);
-    }
-
-    private static EntrypointAddress parseEntrypointAddress(JsonValue endpointAddressJson) {
-        String ip = endpointAddressJson.asObject().get("ip").asString();
-        Map<String, Object> additionalProperties = parseAdditionalProperties(endpointAddressJson);
-        return new EntrypointAddress(ip, additionalProperties);
-    }
-
-    private static Map<String, Object> parseAdditionalProperties(JsonValue endpointAddressJson) {
-        Set<String> knownFieldNames = new HashSet<String>(Arrays.asList("ip", "nodeName", "targetRef", "hostname"));
-
-        Map<String, Object> result = new HashMap<String, Object>();
-        Iterator<JsonObject.Member> iter = endpointAddressJson.asObject().iterator();
-        while (iter.hasNext()) {
-            JsonObject.Member member = iter.next();
-            if (!knownFieldNames.contains(member.getName())) {
-                result.put(member.getName(), toString(member.getValue()));
-            }
-        }
-        return result;
-    }
-
-    private static JsonArray toJsonArray(JsonValue jsonValue) {
-        if (jsonValue == null || jsonValue.isNull()) {
-            return new JsonArray();
-        } else {
-            return jsonValue.asArray();
-        }
-    }
-
-    private static String toString(JsonValue jsonValue) {
-        if (jsonValue.isString()) {
-            return jsonValue.asString();
-        } else {
-            return jsonValue.toString();
-        }
-    }
-
-    /**
-     * Builds SSL Socket Factory with the public CA Certificate from Kubernetes Master.
-     */
-    private static SSLSocketFactory buildSslSocketFactory() {
-        try {
-            KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-            keyStore.load(null, null);
-            keyStore.setCertificateEntry("ca", generateCertificate());
-
-            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-            tmf.init(keyStore);
-
-            SSLContext context = SSLContext.getInstance("TLS");
-            context.init(null, tmf.getTrustManagers(), null);
-            return context.getSocketFactory();
-
-        } catch (Exception e) {
-            throw new KubernetesClientException("Failure in generating SSLSocketFactory", e);
-        }
-    }
-
-    /**
-     * Generates CA Certificate from the default CA Cert file (which always exists in the Kubernetes POD).
-     */
-    private static Certificate generateCertificate()
-            throws IOException, CertificateException {
-        InputStream caInput = null;
-        try {
-            CertificateFactory cf = CertificateFactory.getInstance("X.509");
-            caInput = new BufferedInputStream(new FileInputStream(new File(caCertPath())));
-            return cf.generateCertificate(caInput);
-        } finally {
-            IOUtil.closeResource(caInput);
-        }
-    }
-
-    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
-    private static String caCertPath() {
-        return "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
-    }
+    Endpoints endpointsByName(String namespace, String endpointName);
 
     /**
      * Result which stores the information about all addresses.
      */
-    static final class Endpoints {
+    final class Endpoints {
         private final List<EntrypointAddress> addresses;
         private final List<EntrypointAddress> notReadyAddresses;
 
@@ -270,7 +79,7 @@ class KubernetesClient {
     /**
      * Result which stores the information about a single address.
      */
-    static final class EntrypointAddress {
+    final class EntrypointAddress {
         private final String ip;
         private final Map<String, Object> additionalProperties;
 

--- a/src/main/java/com/hazelcast/kubernetes/RetryKubernetesClient.java
+++ b/src/main/java/com/hazelcast/kubernetes/RetryKubernetesClient.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.kubernetes;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Connects to Kubernetes API with retries.
+ */
+class RetryKubernetesClient
+        implements KubernetesClient {
+    private static final int DEFAULT_RETRIES = 10;
+
+    private final KubernetesClient kubernetesClient;
+    private final int retries;
+
+    RetryKubernetesClient(KubernetesClient kubernetesClient, int retries) {
+        this.kubernetesClient = kubernetesClient;
+        this.retries = retries;
+    }
+
+    RetryKubernetesClient(KubernetesClient kubernetesClient) {
+        this(kubernetesClient, DEFAULT_RETRIES);
+    }
+
+    @Override
+    public Endpoints endpoints(final String namespace) {
+        return RetryUtils.retry(new Callable<Endpoints>() {
+            @Override
+            public Endpoints call()
+                    throws Exception {
+                return kubernetesClient.endpoints(namespace);
+            }
+        }, retries);
+    }
+
+    @Override
+    public Endpoints endpointsByLabel(final String namespace, final String serviceLabel, final String serviceLabelValue) {
+        return RetryUtils.retry(new Callable<Endpoints>() {
+            @Override
+            public Endpoints call()
+                    throws Exception {
+                return kubernetesClient.endpointsByLabel(namespace, serviceLabel, serviceLabelValue);
+            }
+        }, retries);
+    }
+
+    @Override
+    public Endpoints endpointsByName(final String namespace, final String endpointName) {
+        return RetryUtils.retry(new Callable<Endpoints>() {
+            @Override
+            public Endpoints call()
+                    throws Exception {
+                return kubernetesClient.endpointsByName(namespace, endpointName);
+            }
+        }, retries);
+    }
+}

--- a/src/main/java/com/hazelcast/kubernetes/RetryUtils.java
+++ b/src/main/java/com/hazelcast/kubernetes/RetryUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.kubernetes;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.util.ExceptionUtil;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Static utility class to retry operations related to connecting to Kubernetes master.
+ */
+final class RetryUtils {
+    static final long INITIAL_BACKOFF_MS = 1500L;
+    static final long MAX_BACKOFF_MS = 5 * 60 * 1000L;
+    static final double BACKOFF_MULTIPLIER = 1.5;
+
+    private static final ILogger LOGGER = Logger.getLogger(RetryUtils.class);
+
+    private static final long MS_IN_SECOND = 1000L;
+
+    private RetryUtils() {
+    }
+
+    /**
+     * Calls {@code callable.call()} until it does not throw an exception (but no more than {@code retries} times).
+     * <p>
+     * Note that {@code callable} should be an idempotent operation which is a call to the Kubernetes master.
+     * <p>
+     * If {@code callable} throws an unchecked exception, it is wrapped into {@link HazelcastException}.
+     */
+    public static <T> T retry(Callable<T> callable, int retries) {
+        int retryCount = 0;
+        while (true) {
+            try {
+                return callable.call();
+            } catch (Exception e) {
+                retryCount++;
+                if (retryCount > retries) {
+                    throw ExceptionUtil.rethrow(e);
+                }
+                long waitIntervalMs = backoffIntervalForRetry(retryCount);
+                LOGGER.warning(
+                        String.format("Couldn't connect to the Kubernetes master, [%s] retrying in %s seconds...", retryCount,
+                                waitIntervalMs / MS_IN_SECOND));
+                sleep(waitIntervalMs);
+            }
+        }
+    }
+
+    private static long backoffIntervalForRetry(int retryCount) {
+        long result = INITIAL_BACKOFF_MS;
+        for (int i = 1; i < retryCount; i++) {
+            result *= BACKOFF_MULTIPLIER;
+            if (result > MAX_BACKOFF_MS) {
+                return MAX_BACKOFF_MS;
+            }
+        }
+        return result;
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new HazelcastException(e);
+        }
+    }
+}

--- a/src/main/java/com/hazelcast/kubernetes/ServiceEndpointResolver.java
+++ b/src/main/java/com/hazelcast/kubernetes/ServiceEndpointResolver.java
@@ -65,7 +65,7 @@ class ServiceEndpointResolver
             token = getAccountToken();
         }
         logger.info("Kubernetes Discovery: Bearer Token { " + token + " }");
-        return new KubernetesClient(kubernetesMaster, token);
+        return new RetryKubernetesClient(new DefaultKubernetesClient(kubernetesMaster, token));
     }
 
     @Override
@@ -91,7 +91,7 @@ class ServiceEndpointResolver
         }
     }
 
-    private void resolveAddresses(List<DiscoveryNode> discoveredNodes, List<KubernetesClient.EntrypointAddress> addresses) {
+    private void resolveAddresses(List<DiscoveryNode> discoveredNodes, List<EntrypointAddress> addresses) {
         for (EntrypointAddress address : addresses) {
             addAddress(discoveredNodes, address);
         }

--- a/src/test/java/com/hazelcast/kubernetes/DefaultKubernetesClientTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/DefaultKubernetesClientTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.kubernetes;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.hazelcast.kubernetes.KubernetesClient.Endpoints;
+import com.hazelcast.kubernetes.KubernetesClient.EntrypointAddress;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -34,7 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertTrue;
 
-public class KubernetesClientTest {
+public class DefaultKubernetesClientTest {
     private static final String KUBERNETES_MASTER_IP = "localhost";
     private static final int KUBERNETES_MASTER_PORT = 8089;
     private static final String KUBERNETES_MASTER_URL = String
@@ -55,7 +56,7 @@ public class KubernetesClientTest {
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(KUBERNETES_MASTER_PORT);
 
-    private final KubernetesClient kubernetesClient = new KubernetesClient(KUBERNETES_MASTER_URL, TOKEN);
+    private final DefaultKubernetesClient kubernetesClient = new DefaultKubernetesClient(KUBERNETES_MASTER_URL, TOKEN);
 
     @Test
     public void endpointsByNamespace() {
@@ -304,9 +305,9 @@ public class KubernetesClientTest {
         return "malformed response";
     }
 
-    private static List<String> extractIpPort(List<KubernetesClient.EntrypointAddress> addresses) {
+    private static List<String> extractIpPort(List<EntrypointAddress> addresses) {
         List<String> result = new ArrayList<String>();
-        for (KubernetesClient.EntrypointAddress address : addresses) {
+        for (EntrypointAddress address : addresses) {
             String ip = address.getIp();
             String port = String.valueOf(address.getAdditionalProperties().get("hazelcast-service-port"));
             result.add(ipPort(ip, port));

--- a/src/test/java/com/hazelcast/kubernetes/DnsEndpointResolverTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/DnsEndpointResolverTest.java
@@ -31,7 +31,7 @@ public class DnsEndpointResolverTest {
     private static final int SERVICE_DNS_TIMEOUT = 5;
 
     @Mock
-    private KubernetesClient client;
+    private DefaultKubernetesClient client;
 
     @Mock
     private Lookup lookup;
@@ -42,7 +42,7 @@ public class DnsEndpointResolverTest {
     @Before
     public void setup()
             throws Exception {
-        PowerMockito.whenNew(KubernetesClient.class).withAnyArguments().thenReturn(client);
+        PowerMockito.whenNew(DefaultKubernetesClient.class).withAnyArguments().thenReturn(client);
         PowerMockito.whenNew(SRVRecord.class).withAnyArguments().thenReturn(srvRecord);
         when(srvRecord.getTarget()).thenReturn(Name.fromString("127.0.0.1"));
     }

--- a/src/test/java/com/hazelcast/kubernetes/KubernetesDiscoveryStrategyFactoryTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/KubernetesDiscoveryStrategyFactoryTest.java
@@ -30,12 +30,12 @@ public class KubernetesDiscoveryStrategyFactoryTest {
     DiscoveryNode discoveryNode;
 
     @Mock
-    private KubernetesClient client;
+    private DefaultKubernetesClient client;
 
     @Before
     public void setup()
             throws Exception {
-        PowerMockito.whenNew(KubernetesClient.class).withAnyArguments().thenReturn(client);
+        PowerMockito.whenNew(DefaultKubernetesClient.class).withAnyArguments().thenReturn(client);
     }
 
     @Test

--- a/src/test/java/com/hazelcast/kubernetes/RetryKubernetesClientTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/RetryKubernetesClientTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.kubernetes;
+
+import com.hazelcast.kubernetes.KubernetesClient.Endpoints;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RetryKubernetesClientTest {
+    private static final int RETRIES = 1;
+
+    private static final String NAMESPACE = "someNamespace";
+    private static final String SERVICE_LABEL = "someServiceLabel";
+    private static final String SERVICE_LABEL_VALUE = "someServiceLabelValue";
+    private static final String SERVICE_NAME = "someServiceName";
+
+    private static final Endpoints ENDPOINTS = new Endpoints(null, null);
+
+    @Mock
+    KubernetesClient mockClient;
+
+    private RetryKubernetesClient client;
+
+    @Before
+    public void setUp() {
+        client = new RetryKubernetesClient(mockClient, RETRIES);
+
+        when(mockClient.endpoints(anyString())).thenReturn(ENDPOINTS);
+        when(mockClient.endpointsByLabel(anyString(), anyString(), anyString())).thenReturn(ENDPOINTS);
+        when(mockClient.endpointsByName(anyString(), anyString())).thenReturn(ENDPOINTS);
+    }
+
+    @Test
+    public void endpoints() {
+        // given
+        given(mockClient.endpoints(NAMESPACE)).willThrow(KubernetesClientException.class).willReturn(ENDPOINTS);
+
+        // when
+        Endpoints result = client.endpoints(NAMESPACE);
+
+        // then
+        assertEquals(ENDPOINTS, result);
+    }
+
+    @Test(expected = KubernetesClientException.class)
+    public void endpointsRetriesExceeded() {
+        // given
+        given(mockClient.endpoints(NAMESPACE)).willThrow(KubernetesClientException.class)
+                                              .willThrow(KubernetesClientException.class).willReturn(ENDPOINTS);
+
+        // when
+        Endpoints result = client.endpoints(NAMESPACE);
+
+        // then
+        // throws exception
+    }
+
+    @Test
+    public void endpointsByLabel() {
+        // given
+        given(mockClient.endpointsByLabel(NAMESPACE, SERVICE_LABEL, SERVICE_LABEL_VALUE))
+                .willThrow(KubernetesClientException.class).willReturn(ENDPOINTS);
+
+        // when
+        Endpoints result = client.endpointsByLabel(NAMESPACE, SERVICE_LABEL, SERVICE_LABEL_VALUE);
+
+        // then
+        assertEquals(ENDPOINTS, result);
+    }
+
+    @Test(expected = KubernetesClientException.class)
+    public void endpointsByLabelRetriesExceeded() {
+        // given
+        given(mockClient.endpointsByLabel(NAMESPACE, SERVICE_LABEL, SERVICE_LABEL_VALUE))
+                .willThrow(KubernetesClientException.class)
+                .willThrow(KubernetesClientException.class).willReturn(ENDPOINTS);
+
+        // when
+        Endpoints result = client.endpointsByLabel(NAMESPACE, SERVICE_LABEL, SERVICE_LABEL_VALUE);
+
+        // then
+        // throws exception
+    }
+
+    @Test
+    public void endpointsByName() {
+        // given
+        given(mockClient.endpointsByName(NAMESPACE, SERVICE_NAME))
+                .willThrow(KubernetesClientException.class).willReturn(ENDPOINTS);
+
+        // when
+        Endpoints result = client.endpointsByName(NAMESPACE, SERVICE_NAME);
+
+        // then
+        assertEquals(ENDPOINTS, result);
+    }
+
+    @Test(expected = KubernetesClientException.class)
+    public void endpointsByNameRetriesExceeded() {
+        // given
+        given(mockClient.endpointsByName(NAMESPACE, SERVICE_NAME))
+                .willThrow(KubernetesClientException.class)
+                .willThrow(KubernetesClientException.class).willReturn(ENDPOINTS);
+
+        // when
+        Endpoints result = client.endpointsByName(NAMESPACE, SERVICE_NAME);
+
+        // then
+        // throws exception
+    }
+}

--- a/src/test/java/com/hazelcast/kubernetes/RetryUtilsTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/RetryUtilsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.kubernetes;
+
+import com.hazelcast.core.HazelcastException;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+
+import static com.hazelcast.kubernetes.RetryUtils.BACKOFF_MULTIPLIER;
+import static com.hazelcast.kubernetes.RetryUtils.INITIAL_BACKOFF_MS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class RetryUtilsTest {
+    private static final Integer RETRIES = 1;
+    private static final String RESULT = "result string";
+
+    private Callable<String> callable = mock(Callable.class);
+
+    @Test
+    public void retryNoRetries()
+            throws Exception {
+        // given
+        given(callable.call()).willReturn(RESULT);
+
+        // when
+        String result = RetryUtils.retry(callable, RETRIES);
+
+        // then
+        assertEquals(RESULT, result);
+        verify(callable).call();
+    }
+
+    @Test
+    public void retryRetriesSuccessful()
+            throws Exception {
+        // given
+        given(callable.call()).willThrow(new RuntimeException()).willReturn(RESULT);
+
+        // when
+        String result = RetryUtils.retry(callable, RETRIES);
+
+        // then
+        assertEquals(RESULT, result);
+        verify(callable, times(2)).call();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void retryRetriesFailed()
+            throws Exception {
+        // given
+        given(callable.call()).willThrow(new RuntimeException()).willThrow(new RuntimeException()).willReturn(RESULT);
+
+        // when
+        RetryUtils.retry(callable, RETRIES);
+
+        // then
+        // throws exception
+    }
+
+    @Test(expected = HazelcastException.class)
+    public void retryRetriesFailedUncheckedException()
+            throws Exception {
+        // given
+        given(callable.call()).willThrow(new Exception()).willThrow(new Exception()).willReturn(RESULT);
+
+        // when
+        RetryUtils.retry(callable, RETRIES);
+
+        // then
+        // throws exception
+    }
+
+    @Test
+    public void retryRetriesWaitExponentialBackoff()
+            throws Exception {
+        // given
+        double twoBackoffIntervalsMs = INITIAL_BACKOFF_MS + (BACKOFF_MULTIPLIER * INITIAL_BACKOFF_MS);
+        given(callable.call()).willThrow(new RuntimeException()).willThrow(new RuntimeException()).willReturn(RESULT);
+
+        // when
+        long startTimeMs = System.currentTimeMillis();
+        RetryUtils.retry(callable, 5);
+        long endTimeMs = System.currentTimeMillis();
+
+        // then
+        assertTrue(twoBackoffIntervalsMs < (endTimeMs - startTimeMs));
+    }
+
+}

--- a/src/test/java/com/hazelcast/kubernetes/ServiceEndpointResolverTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/ServiceEndpointResolverTest.java
@@ -43,12 +43,12 @@ public class ServiceEndpointResolverTest {
     private static final String API_TOKEN = "token";
 
     @Mock
-    private KubernetesClient client;
+    private RetryKubernetesClient client;
 
     @Before
     public void setup()
             throws Exception {
-        PowerMockito.whenNew(KubernetesClient.class).withAnyArguments().thenReturn(client);
+        PowerMockito.whenNew(RetryKubernetesClient.class).withAnyArguments().thenReturn(client);
     }
 
     @Test


### PR DESCRIPTION
Make each call to Kubernetes API retried in case of failures. It prevents issues when the Kubernetes Master is overloaded.

fix #78
fix #28

Changes:
- Extract interface `KubernetesClient`, so that there'd be `DefaultKubernetesClient` which implements `KubernetesClient`
- Create `RetryKubernetesClient` which uses Decorator Patter to "decorate" `KubernetesClient` with retries

Notes to reviewers:
- It may seem like a lot of code changes, but actually there is no code change in `KubernetesClient` and `DefaultKubernetesClient`, it's just renaming plus splitting into two classes; the only added code is actually `RetryUtils` and `RetryKubernetesClient`
- `RetryUtils` is almost identically copied from `hazelcast-aws` [1]; It seems like a bad sign and breaking SRP, but IMO this one class is not enough to create additional library to share the code between `hazelcast-aws` and `hazelcast-kubernetes`

[1] https://github.com/hazelcast/hazelcast-aws/blob/master/src/main/java/com/hazelcast/aws/utility/RetryUtils.java