### PR TITLE
Use specific "TLSv1.2" instead of "TLS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ To use Hazelcast embedded in your application, you need to add the plugin depend
 
 ***NOTE:*** If you also have the direct dependency to `hazelcast` specified, then please note that hazelcast-kubernetes 1.3+ is compatible with hazelcast 3.11+ and for older hazelcast verions you need to use hazelcast-kubernetes 1.2.
 
+***NOTE:*** Your Java Runtime Environment must support TLS 1.2 (which is the case for most modern JREs).
+
 #### Maven
 
 ```xml

--- a/src/main/java/com/hazelcast/kubernetes/DefaultKubernetesClient.java
+++ b/src/main/java/com/hazelcast/kubernetes/DefaultKubernetesClient.java
@@ -196,7 +196,7 @@ class DefaultKubernetesClient
             TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
             tmf.init(keyStore);
 
-            SSLContext context = SSLContext.getInstance("TLS");
+            SSLContext context = SSLContext.getInstance("TLSv1.2");
             context.init(null, tmf.getTrustManagers(), null);
             return context.getSocketFactory();
 


### PR DESCRIPTION
fix https://github.com/hazelcast/hazelcast/issues/13760

The issue is that certain JRE implementations don't use TLSv1.2 by default, but uses TLSv1.0 by default. An example of that is IBM Java. By being specific, all JRE which supports TLS 1.2 should work fine.

Tested on: OpenJDK, Oracle, IBM.

After merging this PR, we'll need to do 2 releases:
- patch release from master (1.3.1)
- similar PR to the branch "maintenance-1.2.x" and patch release (1.2.1)