### PR TITLE
Changed hazelcast dependency scope to provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast</artifactId>
       <version>${hazelcast.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
hazelcast-kubernetes was depending on hazelcast, since hazelcast-jet also depends on hazelcast there might be some clashes on the classpath when hazelcast-jet and hazelcast-kubernetes used together. 
