### PR TITLE
Change Retry error log message

### DIFF
--- a/src/main/java/com/hazelcast/kubernetes/RetryUtils.java
+++ b/src/main/java/com/hazelcast/kubernetes/RetryUtils.java
@@ -58,8 +58,8 @@ final class RetryUtils {
                 }
                 long waitIntervalMs = backoffIntervalForRetry(retryCount);
                 LOGGER.warning(
-                        String.format("Couldn't connect to the Kubernetes master, [%s] retrying in %s seconds...", retryCount,
-                                waitIntervalMs / MS_IN_SECOND));
+                        String.format("Couldn't find Hazelcast members using Kubernetes API, [%s] retrying in %s seconds...",
+                                retryCount, waitIntervalMs / MS_IN_SECOND));
                 sleep(waitIntervalMs);
             }
         }

--- a/src/main/java/com/hazelcast/kubernetes/RetryUtils.java
+++ b/src/main/java/com/hazelcast/kubernetes/RetryUtils.java
@@ -58,7 +58,7 @@ final class RetryUtils {
                 }
                 long waitIntervalMs = backoffIntervalForRetry(retryCount);
                 LOGGER.warning(
-                        String.format("Couldn't find Hazelcast members using Kubernetes API, [%s] retrying in %s seconds...",
+                        String.format("Couldn't discover Hazelcast members using Kubernetes API, [%s] retrying in %s seconds...",
                                 retryCount, waitIntervalMs / MS_IN_SECOND));
                 sleep(waitIntervalMs);
             }


### PR DESCRIPTION
The current message is misleading, because it mentioned Kubernetes master, which is not always the issue for retrying.

Related to #132 