### PR TITLE
#146: Added boolean parameter use-node-name-as-external-address, defa…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ build/
 *.iws
 .DS_Store
 atlassian-ide-plugin.xml
+.checkstyle
+.fbExcludeFilterFile

--- a/README.md
+++ b/README.md
@@ -119,11 +119,12 @@ config.getNetworkConfig().getJoin().getKubernetesConfig().setEnabled(true)
       .setProperty("service-name", "MY-SERVICE-NAME");
 ```
 
-There are 4 properties to configure the plugin, all of them are optional.
+There are several properties to configure the plugin, all of them are optional.
  * `namespace`: Kubernetes Namespace where Hazelcast is running; if not specified, the value is taken from the environment variables `KUBERNETES_NAMESPACE` or `OPENSHIFT_BUILD_NAMESPACE`
  * `service-name`: service name used to scan only PODs connected to the given service; if not specified, then all PODs in the namespace are checked
  * `service-label-name`, `service-label-value`: service label and value used to tag services that should form the Hazelcast cluster together
  * `resolve-not-ready-addresses`: if set to `true`, it checks also the addresses of PODs which are not ready; `false` by default
+ * `use-node-name-as-external-address`: if set to `true`, uses the node name to connect to a `NodePort` service instead of looking up the external IP using the API; `false` by default
  * `kubernetes-api-retries`: number of retries in case of issues while connecting to Kubernetes API; defaults to `3` 
  * `kubernetes-master`: URL of Kubernetes Master; `https://kubernetes.default.svc` by default
  * `api-token`: API Token to Kubernetes API; if not specified, the value is taken from the file `/var/run/secrets/kubernetes.io/serviceaccount/token`

--- a/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -56,7 +56,7 @@ final class HazelcastKubernetesDiscoveryStrategy
 
     private static KubernetesClient buildKubernetesClient(KubernetesConfig config) {
         return new KubernetesClient(config.getNamespace(), config.getKubernetesMasterUrl(), config.getKubernetesApiToken(),
-                config.getKubernetesCaCertificate(), config.getKubernetesApiRetries());
+                config.getKubernetesCaCertificate(), config.getKubernetesApiRetries(), config.isUseNodeNameAsExternalAddress());
     }
 
     public void start() {

--- a/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
@@ -44,6 +44,7 @@ public class HazelcastKubernetesDiscoveryStrategyFactory
                 KubernetesProperties.SERVICE_LABEL_VALUE,
                 KubernetesProperties.NAMESPACE,
                 KubernetesProperties.RESOLVE_NOT_READY_ADDRESSES,
+                KubernetesProperties.USE_NODE_NAME_AS_EXTERNAL_ADDRESS,
                 KubernetesProperties.KUBERNETES_API_RETIRES,
                 KubernetesProperties.KUBERNETES_MASTER_URL,
                 KubernetesProperties.KUBERNETES_API_TOKEN,

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -40,6 +40,7 @@ import static java.util.Collections.emptyList;
  *
  * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/">Kubernetes API</a>
  */
+@SuppressWarnings("checkstyle:methodcount")
 class KubernetesClient {
     private static final ILogger LOGGER = Logger.getLogger(KubernetesClient.class);
 
@@ -303,13 +304,7 @@ class KubernetesClient {
                     if (cachedNodePublicIps.containsKey(node)) {
                         nodePublicAddress = cachedNodePublicIps.get(node);
                     } else {
-                        if (useNodeNameAsExternalAddress) {
-                            LOGGER.info("Using node name instead of public IP for node, must be available from client: " + node);
-                            nodePublicAddress = node;
-                        } else {
-                            String nodeUrl = String.format("%s/api/v1/nodes/%s", kubernetesMaster, node);
-                            nodePublicAddress = extractNodePublicIp(callGet(nodeUrl));
-                        }
+                        nodePublicAddress = externalAddressForNode(node);
                         cachedNodePublicIps.put(node, nodePublicAddress);
                     }
                     publicIps.put(privateAddress, nodePublicAddress);
@@ -428,6 +423,18 @@ class KubernetesClient {
             throw new KubernetesClientException("Cannot fetch nodePort from the service");
         }
         return ports.get(0).asObject().get("nodePort").asInt();
+    }
+
+    private String externalAddressForNode(String node) {
+        String nodeExternalAddress;
+        if (useNodeNameAsExternalAddress) {
+            LOGGER.info("Using node name instead of public IP for node, must be available from client: " + node);
+            nodeExternalAddress = node;
+        } else {
+            String nodeUrl = String.format("%s/api/v1/nodes/%s", kubernetesMaster, node);
+            nodeExternalAddress = extractNodePublicIp(callGet(nodeUrl));
+        }
+        return nodeExternalAddress;
     }
 
     private static String extractNodePublicIp(JsonObject nodeJson) {

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -304,9 +304,7 @@ class KubernetesClient {
                         nodePublicAddress = cachedNodePublicIps.get(node);
                     } else {
                         if (useNodeNameAsExternalAddress) {
-                            String msg = "Failed to find public IP for node, using node name instead"
-                                    + " (must be available from client): " + node;
-                            LOGGER.info(msg);
+                            LOGGER.info("Using node name instead of public IP for node, must be available from client: " + node);
                             nodePublicAddress = node;
                         } else {
                             String nodeUrl = String.format("%s/api/v1/nodes/%s", kubernetesMaster, node);

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
@@ -41,6 +41,7 @@ import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_NAME;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_VALUE;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_NAME;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_PORT;
+import static com.hazelcast.kubernetes.KubernetesProperties.USE_NODE_NAME_AS_EXTERNAL_ADDRESS;
 
 /**
  * Responsible for fetching, parsing, and validating Hazelcast Kubernetes Discovery Strategy input properties.
@@ -60,6 +61,7 @@ final class KubernetesConfig {
     private final String serviceLabelValue;
     private final String namespace;
     private final boolean resolveNotReadyAddresses;
+    private final boolean useNodeNameAsExternalAddress;
     private final int kubernetesApiRetries;
     private final String kubernetesMasterUrl;
     private final String kubernetesApiToken;
@@ -77,6 +79,8 @@ final class KubernetesConfig {
         this.serviceLabelValue = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_LABEL_VALUE, "true");
         this.namespace = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, NAMESPACE, getNamespaceOrDefault());
         this.resolveNotReadyAddresses = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, RESOLVE_NOT_READY_ADDRESSES, false);
+        this.useNodeNameAsExternalAddress
+                = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, USE_NODE_NAME_AS_EXTERNAL_ADDRESS, false);
         this.kubernetesApiRetries
                 = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, KUBERNETES_API_RETIRES, DEFAULT_KUBERNETES_API_RETRIES);
         this.kubernetesMasterUrl = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, KUBERNETES_MASTER_URL, DEFAULT_MASTER_URL);
@@ -253,6 +257,10 @@ final class KubernetesConfig {
 
     boolean isResolveNotReadyAddresses() {
         return resolveNotReadyAddresses;
+    }
+
+    boolean isUseNodeNameAsExternalAddress() {
+        return useNodeNameAsExternalAddress;
     }
 
     int getKubernetesApiRetries() {

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
@@ -294,6 +294,7 @@ final class KubernetesConfig {
                 + "service-label-value: " + serviceLabelValue + ", "
                 + "namespace: " + namespace + ", "
                 + "resolve-not-ready-addresses: " + resolveNotReadyAddresses + ", "
+                + "use-node-name-as-external-address: " + useNodeNameAsExternalAddress + ", "
                 + "kubernetes-api-retries: " + kubernetesApiRetries + ", "
                 + "kubernetes-master: " + kubernetesMasterUrl + "}";
     }

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
@@ -92,6 +92,14 @@ public final class KubernetesProperties {
     public static final PropertyDefinition RESOLVE_NOT_READY_ADDRESSES = property("resolve-not-ready-addresses", BOOLEAN);
 
     /**
+     * <p>Configuration key: <tt>use-node-name-as-external-address</tt></p>
+     * Defines if the node name should be used as external address, instead of looking up the external IP using
+     * the <code>/nodes</code> resource. Default is false.
+     */
+    public static final PropertyDefinition USE_NODE_NAME_AS_EXTERNAL_ADDRESS = property("use-node-name-as-external-address",
+            BOOLEAN);
+
+    /**
      * <p>Configuration key: <tt>kubernetes-api-retries</tt></p>
      * Defines the number of retries to Kubernetes API. Defaults to: 3.
      */

--- a/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
@@ -60,7 +60,7 @@ public class KubernetesClientTest {
         stubFor(get(urlMatching("/api/.*")).atPriority(5)
                                            .willReturn(aResponse().withStatus(401).withBody("\"reason\":\"Forbidden\"")));
     }
-    
+
     private KubernetesClient newKubernetesClient(boolean useNodeNameAsExternalAddress) {
         String kubernetesMasterUrl = String.format("http://%s:%d", KUBERNETES_MASTER_IP, wireMockRule.port());
         return new KubernetesClient(NAMESPACE, kubernetesMasterUrl, TOKEN, CA_CERTIFICATE, RETRIES, useNodeNameAsExternalAddress);
@@ -440,7 +440,7 @@ public class KubernetesClientTest {
         assertThat(format(result), containsInAnyOrder(ready("192.168.0.25", 5701), ready("172.17.0.5", 5702)));
         assertThat(formatPublic(result), containsInAnyOrder(ready("35.232.226.200", 31916), ready("35.232.226.201", 31917)));
     }
-    
+
     @Test
     public void endpointsByNamespaceWithNodeName() {
         // given

--- a/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
@@ -79,6 +79,7 @@ public class KubernetesConfigTest {
         assertEquals(DiscoveryMode.KUBERNETES_API, config.getMode());
         assertEquals("default", config.getNamespace());
         assertEquals(false, config.isResolveNotReadyAddresses());
+        assertEquals(false, config.isUseNodeNameAsExternalAddress());
         assertEquals(TEST_API_TOKEN, config.getKubernetesApiToken());
         assertEquals(TEST_CA_CERTIFICATE, config.getKubernetesCaCertificate());
     }
@@ -114,6 +115,19 @@ public class KubernetesConfigTest {
         assertEquals(DiscoveryMode.KUBERNETES_API, config.getMode());
         assertEquals(serviceLabelName, config.getServiceLabelName());
         assertEquals(serviceLabelValue, config.getServiceLabelValue());
+    }
+    
+    @Test
+    public void kubernetesApiNodeNameAsExternalAddress() {
+        // given
+        Map<String, Comparable> properties = createProperties();
+        properties.put(KubernetesProperties.USE_NODE_NAME_AS_EXTERNAL_ADDRESS.key(), true);
+
+        // when
+        KubernetesConfig config = new KubernetesConfig(properties);
+
+        // then
+        assertEquals(true, config.isUseNodeNameAsExternalAddress());
     }
 
     @Test(expected = InvalidConfigurationException.class)

--- a/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
@@ -116,7 +116,7 @@ public class KubernetesConfigTest {
         assertEquals(serviceLabelName, config.getServiceLabelName());
         assertEquals(serviceLabelValue, config.getServiceLabelValue());
     }
-    
+
     @Test
     public void kubernetesApiNodeNameAsExternalAddress() {
         // given


### PR DESCRIPTION
Pull request for issue #146; this adds the flag use-node-name-as-external-address to skip looking up the external IP using the /nodes resource.

fix #146 