### PR TITLE
Hazelcast 4.0 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,8 +209,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.0</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.7.3</powermock.version>
 
-    <hazelcast.version>3.11</hazelcast.version>
+    <hazelcast.version>4.0-SNAPSHOT</hazelcast.version>
 
     <maven.checkstyle.plugin.version>2.15</maven.checkstyle.plugin.version>
     <maven.findbugs.plugin.version>3.0.1</maven.findbugs.plugin.version>

--- a/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -33,7 +33,7 @@ final class HazelcastKubernetesDiscoveryStrategy
     private final KubernetesClient client;
     private final EndpointResolver endpointResolver;
 
-    private final Map<String, Object> memberMetadata = new HashMap<String, Object>();
+    private final Map<String, String> memberMetadata = new HashMap<String, String>();
 
     HazelcastKubernetesDiscoveryStrategy(ILogger logger, Map<String, Comparable> properties) {
         super(logger, properties);
@@ -64,7 +64,7 @@ final class HazelcastKubernetesDiscoveryStrategy
     }
 
     @Override
-    public Map<String, Object> discoverLocalMetadata() {
+    public Map<String, String> discoverLocalMetadata() {
         if (memberMetadata.isEmpty()) {
             memberMetadata.put(PartitionGroupMetaData.PARTITION_GROUP_ZONE, discoverZone());
         }

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -213,7 +213,7 @@ class KubernetesClient {
     private static Endpoint extractEntrypointAddress(JsonValue endpointAddressJson, Integer endpointPort, boolean isReady) {
         String ip = endpointAddressJson.asObject().get("ip").asString();
         Integer port = extractHazelcastServicePortFrom(endpointAddressJson, endpointPort);
-        Map<String, Object> additionalProperties = extractAdditionalPropertiesFrom(endpointAddressJson);
+        Map<String, String> additionalProperties = extractAdditionalPropertiesFrom(endpointAddressJson);
         return new Endpoint(new EndpointAddress(ip, port), isReady, additionalProperties);
     }
 
@@ -225,11 +225,11 @@ class KubernetesClient {
         return endpointPort;
     }
 
-    private static Map<String, Object> extractAdditionalPropertiesFrom(JsonValue endpointAddressJson) {
+    private static Map<String, String> extractAdditionalPropertiesFrom(JsonValue endpointAddressJson) {
         Set<String> knownFieldNames = new HashSet<String>(
                 asList("ip", "nodeName", "targetRef", "hostname", "hazelcast-service-port"));
 
-        Map<String, Object> result = new HashMap<String, Object>();
+        Map<String, String> result = new HashMap<String, String>();
         for (JsonObject.Member member : endpointAddressJson.asObject()) {
             if (!knownFieldNames.contains(member.getName())) {
                 result.put(member.getName(), toString(member.getValue()));
@@ -518,7 +518,7 @@ class KubernetesClient {
         private final EndpointAddress privateAddress;
         private final EndpointAddress publicAddress;
         private final boolean isReady;
-        private final Map<String, Object> additionalProperties;
+        private final Map<String, String> additionalProperties;
 
         Endpoint(EndpointAddress privateAddress, boolean isReady) {
             this.privateAddress = privateAddress;
@@ -527,7 +527,7 @@ class KubernetesClient {
             this.additionalProperties = Collections.emptyMap();
         }
 
-        Endpoint(EndpointAddress privateAddress, boolean isReady, Map<String, Object> additionalProperties) {
+        Endpoint(EndpointAddress privateAddress, boolean isReady, Map<String, String> additionalProperties) {
             this.privateAddress = privateAddress;
             this.publicAddress = null;
             this.isReady = isReady;
@@ -535,7 +535,7 @@ class KubernetesClient {
         }
 
         Endpoint(EndpointAddress privateAddress, EndpointAddress publicAddress, boolean isReady,
-                 Map<String, Object> additionalProperties) {
+                 Map<String, String> additionalProperties) {
             this.privateAddress = privateAddress;
             this.publicAddress = publicAddress;
             this.isReady = isReady;
@@ -554,7 +554,7 @@ class KubernetesClient {
             return isReady;
         }
 
-        Map<String, Object> getAdditionalProperties() {
+        Map<String, String> getAdditionalProperties() {
             return additionalProperties;
         }
     }


### PR DESCRIPTION
* upgraded main hazelcast version to `4.0-SNAPSHOT`
* fixed compile errors

These changes at Hazelcast side broke our plugin master builds. 
https://github.com/hazelcast/hazelcast/commit/6ded404db9a829f4ed9787288941153638ffaf2f#diff-2e6b6ed6c2d9ee7d94f737362ef53f35
http://jenkins.hazelcast.com/view/Plugins/job/Kubernetes-master/

After we merge this PR, I will configure `Kubernetes-master` job as using new `4.0-compatibility` branch thus failure mails will be prevented. 