### PR TITLE
Move nio package to internal.nio

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
             <Import-Package>
               com.hazelcast.config,com.hazelcast.config.properties,
               com.hazelcast.spi.discovery,com.hazelcast.core,
-              com.hazelcast.logging,com.hazelcast.internal.nio, com.hazelcast.internal.util,
+              com.hazelcast.logging,com.hazelcast.nio,com.hazelcast.internal.nio, com.hazelcast.internal.util,
               com.hazelcast.internal.json,javax.net.ssl,javax.security.auth.x500,
               javax.naming, javax.naming.directory, com.hazelcast.spi.partitiongroup
             </Import-Package>

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
             <Import-Package>
               com.hazelcast.config,com.hazelcast.config.properties,
               com.hazelcast.spi.discovery,com.hazelcast.core,
-              com.hazelcast.logging,com.hazelcast.nio, com.hazelcast.internal.util,
+              com.hazelcast.logging,com.hazelcast.internal.nio, com.hazelcast.internal.util,
               com.hazelcast.internal.json,javax.net.ssl,javax.security.auth.x500,
               javax.naming, javax.naming.directory, com.hazelcast.spi.partitiongroup
             </Import-Package>

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
@@ -18,7 +18,7 @@ package com.hazelcast.kubernetes;
 
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.properties.PropertyDefinition;
-import com.hazelcast.nio.IOUtil;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.util.StringUtil;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 

--- a/src/main/java/com/hazelcast/kubernetes/RestClient.java
+++ b/src/main/java/com/hazelcast/kubernetes/RestClient.java
@@ -18,7 +18,7 @@ package com.hazelcast.kubernetes;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.nio.IOUtil;
+import com.hazelcast.internal.nio.IOUtil;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;

--- a/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.kubernetes;
 
 import com.hazelcast.config.InvalidConfigurationException;
-import com.hazelcast.nio.IOUtil;
+import com.hazelcast.internal.nio.IOUtil;
 import org.junit.Test;
 
 import java.io.BufferedWriter;


### PR DESCRIPTION
There are currently two different `nio` packages one of which is `com.hazelcast.nio` and the other one is `com.hazecast.internal.nio`. The changed ones have been replaced in the code and `com.hazecast.internal.nio` is added to bundle-plugin on pom.xml.