### PR TITLE
Retrieve the namespace from the filesystem instead of defaulting to "default".

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ config.getNetworkConfig().getJoin().getKubernetesConfig().setEnabled(true)
 ```
 
 There are several properties to configure the plugin, all of them are optional.
- * `namespace`: Kubernetes Namespace where Hazelcast is running; if not specified, the value is taken from the environment variables `KUBERNETES_NAMESPACE` or `OPENSHIFT_BUILD_NAMESPACE`
+ * `namespace`: Kubernetes Namespace where Hazelcast is running; if not specified, the value is taken from the environment variables `KUBERNETES_NAMESPACE` or `OPENSHIFT_BUILD_NAMESPACE`. If those are not set, the namespace of the POD will be used (retrieved from `/var/run/secrets/kubernetes.io/serviceaccount/namespace`).
  * `service-name`: service name used to scan only PODs connected to the given service; if not specified, then all PODs in the namespace are checked
  * `service-label-name`, `service-label-value`: service label and value used to tag services that should form the Hazelcast cluster together
  * `pod-label-name`, `pod-label-value`: pod label and value used to tag pods that should form the Hazelcast cluster together.

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
     <junit.version>4.12</junit.version>
     <wiremock.version>2.18.0</wiremock.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <mockito.version>1.10.19</mockito.version>
-    <powermock.version>1.7.3</powermock.version>
+    <mockito.version>2.28.2</mockito.version>
+    <powermock.version>2.0.2</powermock.version>
 
     <hazelcast.version>4.0-SNAPSHOT</hazelcast.version>
 
@@ -163,13 +163,13 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
+      <artifactId>powermock-api-mockito2</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/src/test/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactoryTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactoryTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({KubernetesApiEndpointResolver.class, KubernetesConfig.class})
+@PrepareForTest({KubernetesApiEndpointResolver.class})
 public class HazelcastKubernetesDiscoveryStrategyFactoryTest {
 
     private static final ILogger LOGGER = new NoLogFactory().getLogger("no");
@@ -53,9 +53,6 @@ public class HazelcastKubernetesDiscoveryStrategyFactoryTest {
     public void setup()
             throws Exception {
         PowerMockito.whenNew(KubernetesClient.class).withAnyArguments().thenReturn(client);
-        PowerMockito.spy(KubernetesConfig.class);
-        PowerMockito.doReturn("default")
-                .when(KubernetesConfig.class, "readFileContents", "/var/run/secrets/kubernetes.io/serviceaccount/namespace");
     }
 
     @Test
@@ -79,6 +76,7 @@ public class HazelcastKubernetesDiscoveryStrategyFactoryTest {
         properties.put(KubernetesProperties.KUBERNETES_API_TOKEN.key(), API_TOKEN);
         properties.put(KubernetesProperties.KUBERNETES_CA_CERTIFICATE.key(), CA_CERTIFICATE);
         properties.put(String.valueOf(KubernetesProperties.SERVICE_PORT), 333);
+        properties.put(KubernetesProperties.NAMESPACE.key(), "default");
         HazelcastKubernetesDiscoveryStrategyFactory factory = new HazelcastKubernetesDiscoveryStrategyFactory();
         DiscoveryStrategy strategy = factory.newDiscoveryStrategy(discoveryNode, LOGGER, properties);
         assertTrue(strategy instanceof HazelcastKubernetesDiscoveryStrategy);

--- a/src/test/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactoryTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactoryTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(KubernetesApiEndpointResolver.class)
+@PrepareForTest({KubernetesApiEndpointResolver.class, KubernetesConfig.class})
 public class HazelcastKubernetesDiscoveryStrategyFactoryTest {
 
     private static final ILogger LOGGER = new NoLogFactory().getLogger("no");
@@ -53,6 +53,9 @@ public class HazelcastKubernetesDiscoveryStrategyFactoryTest {
     public void setup()
             throws Exception {
         PowerMockito.whenNew(KubernetesClient.class).withAnyArguments().thenReturn(client);
+        PowerMockito.spy(KubernetesConfig.class);
+        PowerMockito.doReturn("default")
+                .when(KubernetesConfig.class, "readFileContents", "/var/run/secrets/kubernetes.io/serviceaccount/namespace");
     }
 
     @Test

--- a/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.kubernetes;
 
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.internal.nio.IOUtil;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.BufferedWriter;
@@ -28,6 +29,10 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import static com.hazelcast.kubernetes.KubernetesConfig.DiscoveryMode;
 import static com.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_API_RETIRES;
@@ -41,9 +46,17 @@ import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_NAME;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_PORT;
 import static org.junit.Assert.assertEquals;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({KubernetesConfig.class})
 public class KubernetesConfigTest {
     private static final String TEST_API_TOKEN = "api-token";
     private static final String TEST_CA_CERTIFICATE = "ca-certificate";
+
+    @Before
+    public void prepare() throws Exception {
+        PowerMockito.spy(KubernetesConfig.class);
+        PowerMockito.doReturn("default").when(KubernetesConfig.class, "readFileContents", "/var/run/secrets/kubernetes.io/serviceaccount/namespace");
+    }
 
     @Test
     public void dnsLookupMode() {
@@ -68,7 +81,7 @@ public class KubernetesConfigTest {
     }
 
     @Test
-    public void kubernetesApiModeDefault() {
+    public void kubernetesApiModeDefault() throws Exception {
         // given
         Map<String, Comparable> properties = createProperties();
 


### PR DESCRIPTION
Same PR as https://github.com/hazelcast/hazelcast-kubernetes/pull/183 but for the master branch.