### PR TITLE
Optional CA certificate and optional account token

### DIFF
--- a/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
@@ -252,6 +252,18 @@ final class KubernetesConfig {
             throw new InvalidConfigurationException(
                     String.format("Property '%s' cannot be a negative number", SERVICE_PORT.key()));
         }
+        if (getMode().equals(DiscoveryMode.KUBERNETES_API)) {
+            String errorTemplate = "Property '%s' cannot be null when using kubernetes API mode";
+            if (kubernetesCaCertificate == null) {
+                throw new InvalidConfigurationException(
+                        String.format(errorTemplate, KUBERNETES_CA_CERTIFICATE.key()));
+            }
+
+            if (kubernetesApiToken == null) {
+                throw new InvalidConfigurationException(
+                        String.format(errorTemplate, KUBERNETES_API_TOKEN.key()));
+            }
+        }
     }
 
     DiscoveryMode getMode() {

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
@@ -253,15 +253,26 @@ final class KubernetesConfig {
                     String.format("Property '%s' cannot be a negative number", SERVICE_PORT.key()));
         }
         if (getMode().equals(DiscoveryMode.KUBERNETES_API)) {
-            String errorTemplate = "Property '%s' cannot be null when using kubernetes API mode";
             if (kubernetesCaCertificate == null) {
                 throw new InvalidConfigurationException(
-                        String.format(errorTemplate, KUBERNETES_CA_CERTIFICATE.key()));
+                        String.format(
+                                "The value of CA Certificate cannot be found. Please make sure that the file '%s' " +
+                                        "exists or define '%s' in the configuration",
+                                CA_CERTIFICATE_FILENAME,
+                                KUBERNETES_CA_CERTIFICATE.key()
+                        )
+                );
             }
 
             if (kubernetesApiToken == null) {
                 throw new InvalidConfigurationException(
-                        String.format(errorTemplate, KUBERNETES_API_TOKEN.key()));
+                        String.format(
+                                "The value of API token cannot be found. Please make sure that the file '%s' " +
+                                        "exists or define '%s' in the configuration",
+                                ACCOUNT_TOKEN_FILENAME,
+                                KUBERNETES_API_TOKEN.key()
+                        )
+                );
             }
         }
     }

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
@@ -53,6 +53,8 @@ final class KubernetesConfig {
     private static final String DEFAULT_MASTER_URL = "https://kubernetes.default.svc";
     private static final int DEFAULT_SERVICE_DNS_TIMEOUT_SECONDS = 5;
     private static final int DEFAULT_KUBERNETES_API_RETRIES = 3;
+    private static final String ACCOUNT_TOKEN_FILENAME = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+    private static final String CA_CERTIFICATE_FILENAME = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
 
     // Parameters for DNS Lookup mode
     private final String serviceDns;
@@ -127,12 +129,25 @@ final class KubernetesConfig {
 
     @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     private static String readAccountToken() {
-        return readFileContents("/var/run/secrets/kubernetes.io/serviceaccount/token");
+        if (fileExists(ACCOUNT_TOKEN_FILENAME)) {
+            return readFileContents(ACCOUNT_TOKEN_FILENAME);
+        } else {
+            return null;
+        }
     }
 
     @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     private static String readCaCertificate() {
-        return readFileContents("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt");
+        if (fileExists(CA_CERTIFICATE_FILENAME)) {
+            return readFileContents(CA_CERTIFICATE_FILENAME);
+        } else {
+            return null;
+        }
+    }
+
+    private static boolean fileExists(String fileName) {
+        return new File(fileName)
+                .exists();
     }
 
     static String readFileContents(String tokenFile) {

--- a/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
@@ -234,36 +234,52 @@ public class KubernetesConfigTest {
 
     @Test(expected = InvalidConfigurationException.class)
     public void invalidCaCertificateWithKubernetesApiMode() {
+        // given
         Map<String, Comparable> properties = new HashMap<String, Comparable>();
-        properties.put(SERVICE_DNS.key(), null);
 
+        // when
         new KubernetesConfig(properties);
+
+        // then
+        // throws exception
     }
 
     @Test
     public void validCaCertificateWithServiceDnsMode() {
+        // given
         Map<String, Comparable> properties = new HashMap<String, Comparable>();
         properties.put(SERVICE_DNS.key(), "test.dns");
 
+        // when
         KubernetesConfig config = new KubernetesConfig(properties);
+
+        // then
         assertNull(config.getKubernetesCaCertificate());
     }
 
     @Test(expected = InvalidConfigurationException.class)
     public void invalidAccountTokenWithKubernetesApiMode() {
+        // given
         Map<String, Comparable> properties = new HashMap<String, Comparable>();
-        properties.put(SERVICE_DNS.key(), null);
         properties.put(KUBERNETES_CA_CERTIFICATE.key(), TEST_CA_CERTIFICATE);
 
+        // when
         new KubernetesConfig(properties);
+
+        // then
+        // throws exception
     }
 
     @Test
     public void validAccountTokenWithServiceDnsMode() {
+        // given
         Map<String, Comparable> properties = new HashMap<String, Comparable>();
         properties.put(SERVICE_DNS.key(), "test.dns");
 
+        // when
         KubernetesConfig config = new KubernetesConfig(properties);
+
+        // then
         assertNull(config.getKubernetesApiToken());
     }
 

--- a/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
@@ -40,6 +40,7 @@ import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_VALUE;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_NAME;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_PORT;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class KubernetesConfigTest {
     private static final String TEST_API_TOKEN = "api-token";
@@ -229,6 +230,41 @@ public class KubernetesConfigTest {
         String testFile = createTestFile(expectedContents);
         String actualContents = KubernetesConfig.readFileContents(testFile);
         assertEquals(expectedContents, actualContents);
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void invalidCaCertificateWithKubernetesApiMode() {
+        Map<String, Comparable> properties = new HashMap<String, Comparable>();
+        properties.put(SERVICE_DNS.key(), null);
+
+        new KubernetesConfig(properties);
+    }
+
+    @Test
+    public void validCaCertificateWithServiceDnsMode() {
+        Map<String, Comparable> properties = new HashMap<String, Comparable>();
+        properties.put(SERVICE_DNS.key(), "test.dns");
+
+        KubernetesConfig config = new KubernetesConfig(properties);
+        assertNull(config.getKubernetesCaCertificate());
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void invalidAccountTokenWithKubernetesApiMode() {
+        Map<String, Comparable> properties = new HashMap<String, Comparable>();
+        properties.put(SERVICE_DNS.key(), null);
+        properties.put(KUBERNETES_CA_CERTIFICATE.key(), TEST_CA_CERTIFICATE);
+
+        new KubernetesConfig(properties);
+    }
+
+    @Test
+    public void validAccountTokenWithServiceDnsMode() {
+        Map<String, Comparable> properties = new HashMap<String, Comparable>();
+        properties.put(SERVICE_DNS.key(), "test.dns");
+
+        KubernetesConfig config = new KubernetesConfig(properties);
+        assertNull(config.getKubernetesApiToken());
     }
 
     private static String createTestFile(String expectedContents)


### PR DESCRIPTION
DNS resolver do not require tokens or certificate as it only needs to find IP's by DNS.