### PR TITLE
Fix issue that was preventing to use service-dns for Hazelcast 3.x

### DIFF
--- a/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
@@ -241,7 +241,7 @@ final class KubernetesConfig {
     }
 
     DiscoveryMode getMode() {
-        if (serviceDns != null) {
+        if (!StringUtil.isNullOrEmptyAfterTrim(serviceDns)) {
             return DiscoveryMode.DNS_LOOKUP;
         } else {
             return DiscoveryMode.KUBERNETES_API;

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
@@ -205,22 +205,23 @@ final class KubernetesConfig {
     }
 
     private void validateConfig() {
-        if (serviceDns != null && (serviceName != null || serviceLabelName != null || podLabelName != null)) {
+        if (!StringUtil.isNullOrEmptyAfterTrim(serviceDns) && (!StringUtil.isNullOrEmptyAfterTrim(serviceName)
+                || !StringUtil.isNullOrEmptyAfterTrim(serviceLabelName) || !StringUtil.isNullOrEmptyAfterTrim(podLabelName))) {
             throw new InvalidConfigurationException(
                     String.format("Properties '%s' and ('%s' or '%s' or %s) cannot be defined at the same time",
                             SERVICE_DNS.key(), SERVICE_NAME.key(), SERVICE_LABEL_NAME.key(), POD_LABEL_NAME.key()));
         }
-        if (serviceName != null && serviceLabelName != null) {
+        if (!StringUtil.isNullOrEmptyAfterTrim(serviceName) && !StringUtil.isNullOrEmptyAfterTrim(serviceLabelName)) {
             throw new InvalidConfigurationException(
                     String.format("Properties '%s' and '%s' cannot be defined at the same time",
                             SERVICE_NAME.key(), SERVICE_LABEL_NAME.key()));
         }
-        if (serviceName != null && podLabelName != null) {
+        if (!StringUtil.isNullOrEmptyAfterTrim(serviceName) && !StringUtil.isNullOrEmptyAfterTrim(podLabelName)) {
             throw new InvalidConfigurationException(
                     String.format("Properties '%s' and '%s' cannot be defined at the same time",
                             SERVICE_NAME.key(), POD_LABEL_NAME.key()));
         }
-        if (serviceLabelName != null && podLabelName != null) {
+        if (!StringUtil.isNullOrEmptyAfterTrim(serviceLabelName) && !StringUtil.isNullOrEmptyAfterTrim(podLabelName)) {
             throw new InvalidConfigurationException(
                     String.format("Properties '%s' and '%s' cannot be defined at the same time",
                             SERVICE_LABEL_NAME.key(), POD_LABEL_NAME.key()));

--- a/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
@@ -244,4 +244,66 @@ public class KubernetesConfigTest {
         }
         return temp.getAbsolutePath();
     }
+
+    @Test
+    public void propertyServiceNameIsEmpty() {
+        // given
+        Map<String, Comparable> properties = createProperties();
+        properties.put(SERVICE_NAME.key(), "  ");
+        String serviceDns = "service-dns";
+        properties.put(SERVICE_DNS.key(), serviceDns);
+
+        //when
+        KubernetesConfig config = new KubernetesConfig(properties);
+
+        //then
+        assertEquals(serviceDns, config.getServiceDns());
+
+    }
+
+    @Test
+    public void propertyServiceDnsIsNull() {
+        // given
+        Map<String, Comparable> properties = createProperties();
+        String serviceName = "service-name";
+        properties.put(SERVICE_NAME.key(), serviceName);
+        properties.put(SERVICE_DNS.key(), null);
+
+        //when
+        KubernetesConfig config = new KubernetesConfig(properties);
+
+        //then
+        assertEquals(serviceName, config.getServiceName());
+
+    }
+
+    @Test
+    public void emptyProperties() {
+        // given
+        Map<String, Comparable> properties = createProperties();
+        properties.put(SERVICE_LABEL_NAME.key(), "  ");
+        String serviceLabelValue = "service-label-value";
+        properties.put(SERVICE_LABEL_VALUE.key(), serviceLabelValue);
+        properties.put(SERVICE_DNS.key(), "");
+
+        //when
+        KubernetesConfig config = new KubernetesConfig(properties);
+
+        //then
+        assertEquals(serviceLabelValue, config.getServiceLabelValue());
+    }
+
+    @Test
+    public void emptyDnsLookUpMode() {
+
+        // given
+        Map<String, Comparable> properties = createProperties();
+        properties.put(SERVICE_DNS.key(), "  ");
+
+        // when
+        KubernetesConfig config = new KubernetesConfig(properties);
+
+        // then
+        assertEquals(DiscoveryMode.KUBERNETES_API, config.getMode());
+    }
 }


### PR DESCRIPTION
When installed via helm chart, the property service.name is defined by the default in the Hazelcast chart and it cannot be used in conjunction with service-dns, it's needed to use an empty value for service.name, what is not allowed in the current version. This same fix was already done in the version 2.x, but it still was not fixed in the version 1.5.x, which prevents to use service-dns to connect with the version 3.x of Hazelcast.