### PR TITLE
Implement auto detection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <mockito.version>2.28.2</mockito.version>
     <powermock.version>2.0.2</powermock.version>
 
-    <hazelcast.version>4.0</hazelcast.version>
+    <hazelcast.version>4.1-SNAPSHOT</hazelcast.version>
 
     <maven.checkstyle.plugin.version>2.15</maven.checkstyle.plugin.version>
     <maven.findbugs.plugin.version>3.0.4</maven.findbugs.plugin.version>

--- a/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
@@ -75,7 +75,7 @@ public class HazelcastKubernetesDiscoveryStrategyFactory
      * container. That is why we can use it to verify if this code is run in the Kubernetes environment.
      * <p>
      * Note that if the Kubernetes environment is not configured correctly, this file my not exist. However, in such case,
-     * this plugin won't work anyway, so it make sense to return {@code false}.
+     * this plugin won't work anyway, so it makes perfect sense to return {@code false}.
      *
      * @return true if running in the Kubernetes environment
      */

--- a/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
@@ -21,7 +21,9 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -66,5 +68,25 @@ public class HazelcastKubernetesDiscoveryStrategyFactory
 
     public Collection<PropertyDefinition> getConfigurationProperties() {
         return PROPERTY_DEFINITIONS;
+    }
+
+    /**
+     * In all Kubernetes environments the file "/var/run/secrets/kubernetes.io/serviceaccount/token" is injected into the container.
+     * That is why we can use it to verify if this code is run in the Kubernetes environment.
+     * <p>
+     * Note that if the Kubernetes environment is not configured correctly, this file my not exist. However, in such case,
+     * this plugin won't work anyway, so it make sense to return {@code false}.
+     *
+     * @return true if running in the Kubernetes environment
+     */
+    @Override
+    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
+    public boolean isAutoDetectionApplicable() {
+        return new File("/var/run/secrets/kubernetes.io/serviceaccount/token").exists();
+    }
+
+    @Override
+    public DiscoveryStrategyLevel discoveryStrategyLevel() {
+        return DiscoveryStrategyLevel.PLATFORM;
     }
 }

--- a/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategyFactory.java
@@ -71,8 +71,8 @@ public class HazelcastKubernetesDiscoveryStrategyFactory
     }
 
     /**
-     * In all Kubernetes environments the file "/var/run/secrets/kubernetes.io/serviceaccount/token" is injected into the container.
-     * That is why we can use it to verify if this code is run in the Kubernetes environment.
+     * In all Kubernetes environments the file "/var/run/secrets/kubernetes.io/serviceaccount/token" is injected into the
+     * container. That is why we can use it to verify if this code is run in the Kubernetes environment.
      * <p>
      * Note that if the Kubernetes environment is not configured correctly, this file my not exist. However, in such case,
      * this plugin won't work anyway, so it make sense to return {@code false}.


### PR DESCRIPTION
Note that:
- We will need to release with the com.hazelcast:hazelcast:4.1-SNAPSHOT dependency
- This change is 100% backward-compatible (new released `hazelcast-kubernetes` can be used with older hazelcast versions)
- Apart from auto-detection, the logs are improved

----------------------------

After this change, IMO the **newbie experience is great**.

1. Start Hazelcast on Kubernetes
```
$ kubectl run hazelcast --image=leszko/hazelcast
$ kubectl logs hazelcast
...
WARNING: Kubernetes API access is forbidden! Starting standalone. To use Hazelcast Kubernetes discovery configure the required RBAC. For 'default' service account in 'default' namespace execute: `kubectl apply -f https://raw.githubusercontent.com/hazelcast/hazelcast-kubernetes/master/rbac.yaml`
Jul 23, 2020 2:05:32 PM com.hazelcast.internal.cluster.ClusterService
INFO: [10.8.1.4]:5701 [dev] [4.1-SNAPSHOT]

Members {size:1, ver:1} [
        Member [10.8.1.4]:5701 - 44a54bd1-34ca-4f8c-93fe-d1ce594eacac this
]

Jul 23, 2020 2:05:32 PM com.hazelcast.core.LifecycleService
INFO: [10.8.1.4]:5701 [dev] [4.1-SNAPSHOT] [10.8.1.4]:5701 is STARTED
```

2. Execute the recommended command.
```
$ kubectl apply -f https://raw.githubusercontent.com/hazelcast/hazelcast-kubernetes/master/rbac.yaml
```

3. Restart Hazelcast and create two instances
```
$ kubectl delete pod/hazelcast
$ kubectl run hazelcast --image=leszko/hazelcast
$ kubectl run hazelcast-2 --image=leszko/hazelcast
$ kubectl logs hazelcast
...
Members {size:2, ver:2} [
        Member [10.8.1.5]:5701 - 6df84047-4510-460a-ba27-ff75378d217a
        Member [10.8.2.4]:5701 - eb55802e-8358-4931-af88-bac1eaf3819f this
]
```

No configuration needed!