### PR TITLE
Fix rethrowing exception

### DIFF
--- a/src/main/java/com/hazelcast/kubernetes/RetryUtils.java
+++ b/src/main/java/com/hazelcast/kubernetes/RetryUtils.java
@@ -53,7 +53,7 @@ final class RetryUtils {
             } catch (Exception e) {
                 retryCount++;
                 if (retryCount > retries || containsAnyOf(e, nonRetryableKeywords)) {
-                    throw rethrowUnchecked(e);
+                    throw unchecked(e);
                 }
                 long waitIntervalMs = backoffIntervalForRetry(retryCount);
                 LOGGER.warning(
@@ -64,7 +64,7 @@ final class RetryUtils {
         }
     }
 
-    private static RuntimeException rethrowUnchecked(Exception e) {
+    private static RuntimeException unchecked(Exception e) {
         if (e instanceof RuntimeException) {
             return (RuntimeException) e;
         }

--- a/src/main/java/com/hazelcast/kubernetes/RetryUtils.java
+++ b/src/main/java/com/hazelcast/kubernetes/RetryUtils.java
@@ -19,7 +19,6 @@ package com.hazelcast.kubernetes;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.internal.util.ExceptionUtil;
 
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -54,7 +53,7 @@ final class RetryUtils {
             } catch (Exception e) {
                 retryCount++;
                 if (retryCount > retries || containsAnyOf(e, nonRetryableKeywords)) {
-                    throw ExceptionUtil.rethrow(e);
+                    throw rethrowUnchecked(e);
                 }
                 long waitIntervalMs = backoffIntervalForRetry(retryCount);
                 LOGGER.warning(
@@ -63,6 +62,13 @@ final class RetryUtils {
                 sleep(waitIntervalMs);
             }
         }
+    }
+
+    private static RuntimeException rethrowUnchecked(Exception e) {
+        if (e instanceof RuntimeException) {
+            return (RuntimeException) e;
+        }
+        return new HazelcastException(e);
     }
 
     private static boolean containsAnyOf(Exception e, List<String> nonRetryableKeywords) {


### PR DESCRIPTION
It used to use ExceptionUtils.rethrow from Hazelcast core, however its logic has changed and now it always throws HazelcastException.