### PR TITLE
Update rbac.yaml to support external client

### DIFF
--- a/rbac.yaml
+++ b/rbac.yaml
@@ -9,6 +9,7 @@ rules:
       - endpoints
       - pods
       - nodes
+      - services
     verbs:
       - get
       - list


### PR DESCRIPTION
Add permission to query the "services" resource. Needed to support external client.