### PR TITLE
implement node_aware grouping type via exploiting existing ZONE_AWARE impl

### DIFF
--- a/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -157,6 +157,11 @@ class KubernetesClient {
         return extractZone(callGet(nodeUrlString));
     }
 
+    String nodeName(String podName) {
+        String podUrlString = String.format("%s/api/v1/namespaces/%s/pods/%s", kubernetesMaster, namespace, podName);
+        return extractNodeName(callGet(podUrlString));
+    }
+
     private static List<Endpoint> parsePodsList(JsonObject podsListJson) {
         List<Endpoint> addresses = new ArrayList<Endpoint>();
 

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
@@ -142,6 +142,10 @@ public final class KubernetesProperties {
      */
     public static final PropertyDefinition SERVICE_PORT = property("service-port", INTEGER);
 
+    public static final PropertyDefinition ZONE_AWARE = property("zone-aware", BOOLEAN);
+
+    public static final PropertyDefinition NODE_AWARE = property("node-aware", BOOLEAN);
+
     // Prevent instantiation
     private KubernetesProperties() {
     }


### PR DESCRIPTION
This implementation was tested at GKE with multi-node cluster successfully. Two new parameters are introduced with it:
```
    hazelcast:
      partition-group:
        enabled: true
        group-type: ZONE_AWARE
      network:
        join:
          multicast:
            enabled: false
          kubernetes:
            enabled: true
            node-aware: true
            zone-aware: false (by default)
            service-name: hz-service
            namespace: default
```
