### PR TITLE
Add NODE_AWARE metadata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ There are 2 properties to configure the plugin:
 **Note**: In this README, only YAML configurations are presented, however you can achieve exactly the same effect using 
 XML or Java-based configurations.
 
+## High Availability
+
 ### Zone Aware
 
 When using `ZONE_AWARE` configuration, backups are created in the other availability zone. This feature is available only for the Kubernetes API mode.

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Note the following aspects of `NODE_AWARE`:
  * Retrieving name of the node uses Kubernetes API, so RBAC must be configured as described [here](#granting-permissions-to-use-kubernetes-api)
  * `NODE_AWARE` feature works correctly when Hazelcast members are distributed equally in all nodes, so your Kubernetes cluster must orchestrate PODs equally.
  
- Note also that retrieving name of the node assumes that your container's hostname is the same as POD Name, which is almost always true. If you happen to change your hostname in the container, then please define the following environment variable:
+Note also that retrieving name of the node assumes that your container's hostname is the same as POD Name, which is almost always true. If you happen to change your hostname in the container, then please define the following environment variable:
  
  ```yaml
 env:

--- a/README.md
+++ b/README.md
@@ -224,6 +224,42 @@ env:
         fieldPath: metadata.name
  ``` 
 
+### Node Aware
+
+When using `NODE_AWARE` configuration, backups are created in the other Kubernetes nodes. This feature is available only for the Kubernetes API mode.
+
+**Note**: Your Kubernetes cluster must orchestrate Hazelcast Member PODs equally between the nodes, otherwise Node Aware feature may not work correctly.
+
+#### YAML Configuration
+
+```yaml
+partition-group:
+  enabled: true
+  group-type: NODE_AWARE
+```
+
+#### Java-based Configuration
+
+```java
+config.getPartitionGroupConfig()
+    .setEnabled(true)
+    .setGroupType(MemberGroupType.NODE_AWARE);
+```
+
+Note the following aspects of `NODE_AWARE`:
+ * Retrieving name of the node uses Kubernetes API, so RBAC must be configured as described [here](#granting-permissions-to-use-kubernetes-api)
+ * `NODE_AWARE` feature works correctly when Hazelcast members are distributed equally in all nodes, so your Kubernetes cluster must orchestrate PODs equally.
+ 
+ Note also that retrieving name of the node assumes that your container's hostname is the same as POD Name, which is almost always true. If you happen to change your hostname in the container, then please define the following environment variable:
+ 
+ ```yaml
+env:
+  - name: POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+ ``` 
+
 ## Hazelcast Client Configuration
 
 Depending on whether your Hazelcast Client runs inside or outside the Kubernetes cluster, its configuration looks different.

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.7.3</powermock.version>
 
-    <hazelcast.version>3.12.6</hazelcast.version>
+    <hazelcast.version>3.12.11-SNAPSHOT</hazelcast.version>
 
     <maven.checkstyle.plugin.version>2.15</maven.checkstyle.plugin.version>
     <maven.findbugs.plugin.version>3.0.4</maven.findbugs.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.7.3</powermock.version>
 
-    <hazelcast.version>3.12.11-SNAPSHOT</hazelcast.version>
+    <hazelcast.version>3.12.6</hazelcast.version>
 
     <maven.checkstyle.plugin.version>2.15</maven.checkstyle.plugin.version>
     <maven.findbugs.plugin.version>3.0.4</maven.findbugs.plugin.version>

--- a/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -83,13 +83,7 @@ final class HazelcastKubernetesDiscoveryStrategy
     private String discoverZone() {
         if (DiscoveryMode.KUBERNETES_API.equals(config.getMode())) {
             try {
-                String podName = System.getenv("POD_NAME");
-                if (podName == null) {
-                    podName = System.getenv("HOSTNAME");
-                }
-                if (podName == null) {
-                    podName = InetAddress.getLocalHost().getHostName();
-                }
+                String podName = podName();
                 String zone = client.zone(podName);
                 if (zone != null) {
                     getLogger().info(String.format("Kubernetes plugin discovered availability zone: %s", zone));
@@ -112,16 +106,10 @@ final class HazelcastKubernetesDiscoveryStrategy
     private String discoverNodeName() {
         if (DiscoveryMode.KUBERNETES_API.equals(config.getMode())) {
             try {
-                String podName = System.getenv("POD_NAME");
-                if (podName == null) {
-                    podName = System.getenv("HOSTNAME");
-                }
-                if (podName == null) {
-                    podName = InetAddress.getLocalHost().getHostName();
-                }
+                String podName = podName();
                 String nodeName = client.nodeName(podName);
                 if (nodeName != null) {
-                    getLogger().info(String.format("Kubernetes plugin extracted node name: %s", nodeName));
+                    getLogger().info(String.format("Kubernetes plugin discovered node name: %s", nodeName));
                     return nodeName;
                 }
             } catch (Exception e) {
@@ -131,6 +119,17 @@ final class HazelcastKubernetesDiscoveryStrategy
             getLogger().warning("Cannot fetch name of the node, NODE_AWARE feature is disabled");
         }
         return "unknown";
+    }
+
+    private String podName() throws UnknownHostException {
+        String podName = System.getenv("POD_NAME");
+        if (podName == null) {
+            podName = System.getenv("HOSTNAME");
+        }
+        if (podName == null) {
+            podName = InetAddress.getLocalHost().getHostName();
+        }
+        return podName;
     }
 
     @Override

--- a/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -70,7 +70,7 @@ final class HazelcastKubernetesDiscoveryStrategy
     public Map<String, Object> discoverLocalMetadata() {
         if (memberMetadata.isEmpty()) {
             memberMetadata.put(PartitionGroupMetaData.PARTITION_GROUP_ZONE, discoverZone());
-            memberMetadata.put(PartitionGroupMetaData.PARTITION_GROUP_NODE, discoverNodeName());
+            memberMetadata.put("hazelcast.partition.group.node", discoverNodeName());
         }
         return memberMetadata;
     }
@@ -83,8 +83,7 @@ final class HazelcastKubernetesDiscoveryStrategy
     private String discoverZone() {
         if (DiscoveryMode.KUBERNETES_API.equals(config.getMode())) {
             try {
-                String podName = podName();
-                String zone = client.zone(podName);
+                String zone = client.zone(podName());
                 if (zone != null) {
                     getLogger().info(String.format("Kubernetes plugin discovered availability zone: %s", zone));
                     return zone;
@@ -106,8 +105,7 @@ final class HazelcastKubernetesDiscoveryStrategy
     private String discoverNodeName() {
         if (DiscoveryMode.KUBERNETES_API.equals(config.getMode())) {
             try {
-                String podName = podName();
-                String nodeName = client.nodeName(podName);
+                String nodeName = client.nodeName(podName());
                 if (nodeName != null) {
                     getLogger().info(String.format("Kubernetes plugin discovered node name: %s", nodeName));
                     return nodeName;

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -148,8 +148,7 @@ class KubernetesClient {
      * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11">Kubernetes Endpoint API</a>
      */
     String zone(String podName) {
-        String nodeName = nodeName(podName);
-        String nodeUrlString = String.format("%s/api/v1/nodes/%s", kubernetesMaster, nodeName);
+        String nodeUrlString = String.format("%s/api/v1/nodes/%s", kubernetesMaster, nodeName(podName));
         return extractZone(callGet(nodeUrlString));
     }
 

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -148,9 +148,7 @@ class KubernetesClient {
      * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11">Kubernetes Endpoint API</a>
      */
     String zone(String podName) {
-        String podUrlString = String.format("%s/api/v1/namespaces/%s/pods/%s", kubernetesMaster, namespace, podName);
-        String nodeName = extractNodeName(callGet(podUrlString));
-
+        String nodeName = nodeName(podName);
         String nodeUrlString = String.format("%s/api/v1/nodes/%s", kubernetesMaster, nodeName);
         return extractZone(callGet(nodeUrlString));
     }

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -137,7 +137,6 @@ class KubernetesClient {
         }
     }
 
-
     /**
      * Retrieves zone name for the specified {@code namespace} and the given {@code podName}.
      * <p>
@@ -154,6 +153,18 @@ class KubernetesClient {
 
         String nodeUrlString = String.format("%s/api/v1/nodes/%s", kubernetesMaster, nodeName);
         return extractZone(callGet(nodeUrlString));
+    }
+
+    /**
+     * Retrieves node name for the specified {@code namespace} and the given {@code podName}.
+     *
+     * @param podName POD name
+     * @return Node name
+     * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11">Kubernetes Endpoint API</a>
+     */
+    String nodeName(String podName) {
+        String podUrlString = String.format("%s/api/v1/namespaces/%s/pods/%s", kubernetesMaster, namespace, podName);
+        return extractNodeName(callGet(podUrlString));
     }
 
     private static List<Endpoint> parsePodsList(JsonObject podsListJson) {

--- a/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
@@ -371,7 +371,7 @@ public class KubernetesClientTest {
         String podResponse = "{\n"
                 + "  \"kind\": \"Pod\",\n"
                 + "  \"spec\": {\n"
-                + "    \"nodeName\": \"kubernetes-node-default-pool-95e18\"\n"
+                + "    \"nodeName\": \"kubernetes-node-f0bbd602-f7cw\"\n"
                 + "  }\n"
                 + "}";
         stub(String.format("/api/v1/namespaces/%s/pods/%s", NAMESPACE, podName), podResponse);
@@ -380,7 +380,7 @@ public class KubernetesClientTest {
         String nodeName = kubernetesClient.nodeName(podName);
 
         // then
-        assertEquals("kubernetes-node-default-pool-95e18", nodeName);
+        assertEquals("kubernetes-node-f0bbd602-f7cw", nodeName);
     }
 
     @Test

--- a/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/KubernetesClientTest.java
@@ -361,6 +361,28 @@ public class KubernetesClientTest {
         assertEquals("us-central1-a", zone);
     }
 
+
+    @Test
+    public void nodeName() {
+        // given
+        String podName = "pod-name";
+
+        //language=JSON
+        String podResponse = "{\n"
+                + "  \"kind\": \"Pod\",\n"
+                + "  \"spec\": {\n"
+                + "    \"nodeName\": \"kubernetes-node-default-pool-95e18\"\n"
+                + "  }\n"
+                + "}";
+        stub(String.format("/api/v1/namespaces/%s/pods/%s", NAMESPACE, podName), podResponse);
+
+        // when
+        String nodeName = kubernetesClient.nodeName(podName);
+
+        // then
+        assertEquals("kubernetes-node-default-pool-95e18", nodeName);
+    }
+
     @Test
     public void endpointsByNamespaceWithLoadBalancerPublicIp() {
         // given


### PR DESCRIPTION
With `3.12.11 IMDG release`, new metadata/group type introduced to define partition group based on Kubernetes node that Hazelcast cluster runs on. The discovery plugin should pass name of the node to the core SPI via using `discoverLocalMetadata` method like zone info. This method passes both `zone` and `node name` metadata. User can not enable two group types at the same time so cluster will decide which metadata will be used based on cluster config:
```
    hazelcast:
      partition-group:
        enabled: true
        group-type: NODE_AWARE
```
Here is the related [PRD](https://hazelcast.atlassian.net/wiki/spaces/PM/pages/1770291566/Kubernetes+Node+Aware+Partition+Grouping+Support).

These changes will be forward-port to master(2.2.x) branch.

IMDG core counterpart[ PR ](https://github.com/hazelcast/hazelcast/pull/17889).

Todo:

- [x] Add NODE_AWARE section into README 