### PR TITLE
Add publish-snapshot and IMDG-Snapshot actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @leszko @Hazelcast/Integrations
+* @leszko @hasancelik

--- a/.github/workflows/IMDG-snapshot.yml
+++ b/.github/workflows/IMDG-snapshot.yml
@@ -1,4 +1,4 @@
-name: build
+name: IMDG-Snapshot
 on:
   schedule:
     - cron: '0 3 * * *'

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -1,0 +1,30 @@
+name: build
+on:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '8' ]
+        architecture: [ 'x64' ]
+        hazelcast: [ '4.2-SNAPSHOT' ]
+    name: Build against IMDG ${{ matrix.hazelcast }} with JDK ${{ matrix.java }} on ${{ matrix.architecture }}
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Setup JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+          architecture: ${{ matrix.architecture }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Build with Maven
+        run: mvn -Dhazelcast.version=${{ matrix.hazelcast }} -U verify

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -1,9 +1,5 @@
-name: build
+name: Pull-Request
 on:
-  push:
-    branches: master
-    paths-ignore:
-      - '**.md'
   pull_request:
     branches:
       - master

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,47 @@
+name: Publish-Snapshot
+on:
+  push:
+    branches: master
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build and test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '8' ]
+        architecture: [ 'x64' ]
+    name: Build with JDK ${{ matrix.java }} on ${{ matrix.architecture }}
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Setup JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+          architecture: ${{ matrix.architecture }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Build with Maven
+        run: mvn -B verify
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+          server-id: snapshot-repository
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
+      - name: Publish Snapshot JARs
+        run: mvn -B deploy -Prelease-snapshot -DskipTests
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -463,38 +463,6 @@
       </build>
     </profile>
     <profile>
-      <id>master</id>
-      <properties>
-        <hazelcast.version>4.2-SNAPSHOT</hazelcast.version>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>com.hazelcast</groupId>
-          <artifactId>hazelcast</artifactId>
-          <version>${hazelcast.version}</version>
-        </dependency>
-      </dependencies>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${maven.surefire.plugin.version}</version>
-            <configuration combine.self="override">
-              <parallel>none</parallel>
-              <redirectTestOutputToFile>true</redirectTestOutputToFile>
-              <argLine>-Xms128m -Xmx1G -XX:MaxPermSize=128M
-                -Dhazelcast.phone.home.enabled=false
-                -Dhazelcast.mancenter.enabled=false
-                -Dhazelcast.logging.type=none
-                -Dhazelcast.test.use.network=true
-              </argLine>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>release-sign-artifacts</id>
       <activation>
         <property>


### PR DESCRIPTION
`publish-snapshot` build runs unit tests for every push to master and deploy snapshot jars to maven, replacement of jenkins based deploy build.

`IMDG-snapshot` build runs unit tests agains latest IMDG snapshot replacement of jenkins based master build.