### PR TITLE
Avoid reading serviceaccount-token in DNS Mode

### DIFF
--- a/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
@@ -112,7 +112,7 @@ final class KubernetesConfig {
             namespace = System.getenv("OPENSHIFT_BUILD_NAMESPACE");
         }
 
-        if (namespace == null) {
+        if (namespace == null && getMode() == DiscoveryMode.KUBERNETES_API) {
             namespace = readNamespace();
         }
 
@@ -121,7 +121,7 @@ final class KubernetesConfig {
 
     private String getApiToken(Map<String, Comparable> properties) {
         String apiToken = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, KUBERNETES_API_TOKEN);
-        if (apiToken == null) {
+        if (apiToken == null && getMode() == DiscoveryMode.KUBERNETES_API) {
             apiToken = readAccountToken();
         }
         return apiToken;
@@ -129,7 +129,7 @@ final class KubernetesConfig {
 
     private String caCertificate(Map<String, Comparable> properties) {
         String caCertificate = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, KUBERNETES_CA_CERTIFICATE);
-        if (caCertificate == null) {
+        if (caCertificate == null && getMode() == DiscoveryMode.KUBERNETES_API) {
             caCertificate = readCaCertificate();
         }
         return caCertificate;

--- a/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
+++ b/src/test/java/com/hazelcast/kubernetes/KubernetesConfigTest.java
@@ -46,6 +46,7 @@ import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_VALUE;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_NAME;
 import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_PORT;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.powermock.api.mockito.PowerMockito.doReturn;
 
 @RunWith(PowerMockRunner.class)
@@ -75,6 +76,30 @@ public class KubernetesConfigTest {
         assertEquals(serviceDns, config.getServiceDns());
         assertEquals(serviceDnsTimeout, config.getServiceDnsTimeout());
         assertEquals(servicePort, config.getServicePort());
+    }
+
+    @Test
+    public void dnsLookupModeWithoutServiceAccountToken() {
+        // given
+        String serviceDns = "hazelcast.default.svc.cluster.local";
+        int serviceDnsTimeout = 10;
+        int servicePort = 5703;
+
+        Map<String, Comparable> properties = new HashMap<>();
+        properties.put(SERVICE_DNS.key(), serviceDns);
+        properties.put(SERVICE_DNS_TIMEOUT.key(), serviceDnsTimeout);
+        properties.put(SERVICE_PORT.key(), servicePort);
+
+        // when
+        KubernetesConfig config = new KubernetesConfig(properties);
+
+        // then
+        assertEquals(DiscoveryMode.DNS_LOOKUP, config.getMode());
+        assertEquals(serviceDns, config.getServiceDns());
+        assertEquals(serviceDnsTimeout, config.getServiceDnsTimeout());
+        assertEquals(servicePort, config.getServicePort());
+        assertNull(config.getKubernetesApiToken());
+        assertNull(config.getKubernetesCaCertificate());
     }
 
     @Test


### PR DESCRIPTION
Auto-mounting the serviceaccount-token is sometimes disabled to avoid giving applications
access to the kubernetes api when they don't need it. The current method of constructing
an instance of `KubernetesConfig` will try to read the information from the mounted serviceaccount
token even if a Service DNS is specified. This will fail in environments described earlier.

The information gathered from reading the serviceaccount-token fields is only relevant
for API mode. This commit will avoid reading the token if DNS Lookup is configured.

This fixes #284