### PR TITLE
Added documentation for the ability to specify a custom Hazelcast port

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,10 @@ config.getNetworkConfig().getJoin().getKubernetesConfig().setEnabled(true)
       .setProperty("service-dns", "MY-SERVICE-DNS-NAME");
 ```
 
-There are 2 properties to configure the plugin:
+There are 3 properties to configure the plugin:
  * `service-dns` (required): service DNS, usually in the form of `SERVICE-NAME.NAMESPACE.svc.cluster.local`
  * `service-dns-timeout` (optional): custom time for how long the DNS Lookup is checked
+ * `service-port` (optional): the Hazelcast port; if specified with a value greater than 0, it overrides the default (default port = `5701`)
 
 **Note**: In this README, only YAML configurations are presented, however you can achieve exactly the same effect using 
 XML or Java-based configurations.


### PR DESCRIPTION
Added documentation for the ability to specify a custom Hazelcast port through the `service-port` configuration property for DNS lookup. We're using a custom port for Hazelcast on our K8s cluster, and this got me searching for a while. The docs gave me the impression that the `service-port` could not be used for DNS lookup, while it's being used by `HazelcastKubernetesDiscoveryStrategy` to create a `DnsEndpointResolver` (line 44). Seeing this mentioned in the docs might save other people some time.