### PR TITLE
Experiment with Single Member Cluster

### DIFF
--- a/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/kubernetes/HazelcastKubernetesDiscoveryStrategy.java
@@ -51,6 +51,7 @@ final class HazelcastKubernetesDiscoveryStrategy
             endpointResolver = new KubernetesApiEndpointResolver(logger, config.getServiceName(), config.getServicePort(),
                     config.getServiceLabelName(), config.getServiceLabelValue(),
                     config.getPodLabelName(), config.getPodLabelValue(),
+                    config.getMatchServicePodNames(), config.getLbLabelName(), config.getLbLabelValue(),
                     config.isResolveNotReadyAddresses(), client);
         }
 

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolver.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesApiEndpointResolver.java
@@ -35,12 +35,17 @@ class KubernetesApiEndpointResolver
     private final String serviceLabelValue;
     private final String podLabel;
     private final String podLabelValue;
+    private final boolean matchNames;
+    private final String lbLabel;
+    private final String lbLabelValue;
     private final Boolean resolveNotReadyAddresses;
     private final int port;
     private final KubernetesClient client;
 
     KubernetesApiEndpointResolver(ILogger logger, String serviceName, int port,
-                                  String serviceLabel, String serviceLabelValue, String podLabel, String podLabelValue,
+                                  String serviceLabel, String serviceLabelValue,
+                                  String podLabel, String podLabelValue,
+                                  boolean matchNames, String lbLabel, String lbLabelValue,
                                   Boolean resolveNotReadyAddresses, KubernetesClient client) {
 
         super(logger);
@@ -51,6 +56,9 @@ class KubernetesApiEndpointResolver
         this.serviceLabelValue = serviceLabelValue;
         this.podLabel = podLabel;
         this.podLabelValue = podLabelValue;
+        this.matchNames = matchNames;
+        this.lbLabel = lbLabel;
+        this.lbLabelValue = lbLabelValue;
         this.resolveNotReadyAddresses = resolveNotReadyAddresses;
         this.client = client;
     }
@@ -59,15 +67,15 @@ class KubernetesApiEndpointResolver
     List<DiscoveryNode> resolve() {
         if (serviceName != null && !serviceName.isEmpty()) {
             logger.fine("Using service name to discover nodes.");
-            return getSimpleDiscoveryNodes(client.endpointsByName(serviceName));
+            return getSimpleDiscoveryNodes(client.endpointsByName(serviceName, matchNames, lbLabel, lbLabelValue));
         } else if (serviceLabel != null && !serviceLabel.isEmpty()) {
             logger.fine("Using service label to discover nodes.");
-            return getSimpleDiscoveryNodes(client.endpointsByServiceLabel(serviceLabel, serviceLabelValue));
+            return getSimpleDiscoveryNodes(client.endpointsByServiceLabel(serviceLabel, serviceLabelValue, matchNames, lbLabel, lbLabelValue));
         } else if (podLabel != null && !podLabel.isEmpty()) {
             logger.fine("Using pod label to discover nodes.");
-            return getSimpleDiscoveryNodes(client.endpointsByPodLabel(podLabel, podLabelValue));
+            return getSimpleDiscoveryNodes(client.endpointsByPodLabel(podLabel, podLabelValue, matchNames, lbLabel, lbLabelValue));
         }
-        return getSimpleDiscoveryNodes(client.endpoints());
+        return getSimpleDiscoveryNodes(client.endpoints(matchNames, lbLabel, lbLabelValue));
     }
 
     private List<DiscoveryNode> getSimpleDiscoveryNodes(List<Endpoint> endpoints) {

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesClient.java
@@ -75,10 +75,10 @@ class KubernetesClient {
      * @return all POD addresses
      * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#list-143">Kubernetes Endpoint API</a>
      */
-    List<Endpoint> endpoints() {
+    List<Endpoint> endpoints(boolean matchNames, String lbLabel, String lbLabelValue) {
         try {
             String urlString = String.format("%s/api/v1/namespaces/%s/pods", kubernetesMaster, namespace);
-            return enrichWithPublicAddresses(parsePodsList(callGet(urlString)));
+            return enrichWithPublicAddresses(parsePodsList(callGet(urlString)), matchNames, lbLabel, lbLabelValue);
         } catch (RestClientException e) {
             return handleKnownException(e);
         }
@@ -93,11 +93,11 @@ class KubernetesClient {
      * @return all POD addresses from the specified {@code namespace} filtered by the label
      * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#list-143">Kubernetes Endpoint API</a>
      */
-    List<Endpoint> endpointsByServiceLabel(String serviceLabel, String serviceLabelValue) {
+    List<Endpoint> endpointsByServiceLabel(String serviceLabel, String serviceLabelValue, boolean matchNames, String lbLabel, String lbLabelValue) {
         try {
             String param = String.format("labelSelector=%s=%s", serviceLabel, serviceLabelValue);
             String urlString = String.format("%s/api/v1/namespaces/%s/endpoints?%s", kubernetesMaster, namespace, param);
-            return enrichWithPublicAddresses(parseEndpointsList(callGet(urlString)));
+            return enrichWithPublicAddresses(parseEndpointsList(callGet(urlString)), matchNames, lbLabel, lbLabelValue);
         } catch (RestClientException e) {
             return handleKnownException(e);
         }
@@ -110,10 +110,10 @@ class KubernetesClient {
      * @return all POD addresses from the specified {@code namespace} and the given {@code endpointName}
      * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#list-143">Kubernetes Endpoint API</a>
      */
-    List<Endpoint> endpointsByName(String endpointName) {
+    List<Endpoint> endpointsByName(String endpointName, boolean matchNames, String lbLabel, String lbLabelValue) {
         try {
             String urlString = String.format("%s/api/v1/namespaces/%s/endpoints/%s", kubernetesMaster, namespace, endpointName);
-            return enrichWithPublicAddresses(parseEndpoints(callGet(urlString)));
+            return enrichWithPublicAddresses(parseEndpoints(callGet(urlString), false), matchNames, lbLabel, lbLabelValue);
         } catch (RestClientException e) {
             return handleKnownException(e);
         }
@@ -128,11 +128,11 @@ class KubernetesClient {
      * @return all POD addresses from the specified {@code namespace} filtered by the label
      * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#list-143">Kubernetes Endpoint API</a>
      */
-    List<Endpoint> endpointsByPodLabel(String podLabel, String podLabelValue) {
+    List<Endpoint> endpointsByPodLabel(String podLabel, String podLabelValue, boolean matchNames, String lbLabel, String lbLabelValue) {
         try {
             String param = String.format("labelSelector=%s=%s", podLabel, podLabelValue);
             String urlString = String.format("%s/api/v1/namespaces/%s/pods?%s", kubernetesMaster, namespace, param);
-            return enrichWithPublicAddresses(parsePodsList(callGet(urlString)));
+            return enrichWithPublicAddresses(parsePodsList(callGet(urlString)), matchNames, lbLabel, lbLabelValue);
         } catch (RestClientException e) {
             return handleKnownException(e);
         }
@@ -210,24 +210,51 @@ class KubernetesClient {
     private static List<Endpoint> parseEndpointsList(JsonObject endpointsListJson) {
         List<Endpoint> endpoints = new ArrayList<Endpoint>();
         for (JsonValue item : toJsonArray(endpointsListJson.get("items"))) {
-            endpoints.addAll(parseEndpoints(item));
+            endpoints.addAll(parseEndpoints(item, false));
         }
         return endpoints;
     }
 
-    private static List<Endpoint> parseEndpoints(JsonValue endpointItemJson) {
+    private static List<Endpoint> parseEndpoints(JsonValue endpointItemJson, boolean matchNames) {
         List<Endpoint> addresses = new ArrayList<Endpoint>();
+
+        // used by
+        // endpointsByName <- matchNames?
+        // parseEndpointsList <- endpointsByServiceLabel : matchNames?
+        // extractServices <- enrichWithPublicAddresses : use matchNames!
+
+        String endpointName = matchNames ? extractEndpointName(endpointItemJson) : null;
 
         for (JsonValue subset : toJsonArray(endpointItemJson.asObject().get("subsets"))) {
             Integer endpointPort = extractPort(subset);
             for (JsonValue address : toJsonArray(subset.asObject().get("addresses"))) {
+                if (matchNames) {
+                    String targetName = extractTargetName(address);
+                    if (targetName == null || !targetName.equals(endpointName))
+                        continue;
+                }
                 addresses.add(extractEntrypointAddress(address, endpointPort, true));
             }
             for (JsonValue address : toJsonArray(subset.asObject().get("notReadyAddresses"))) {
+                if (matchNames) {
+                    String targetName = extractTargetName(address);
+                    if (targetName == null || !targetName.equals(endpointName))
+                        continue;
+                }
                 addresses.add(extractEntrypointAddress(address, endpointPort, false));
             }
         }
         return addresses;
+    }
+
+    private static String extractEndpointName(JsonValue endpointItemJson) {
+        return endpointItemJson.asObject().get("metadata").asObject().get("name").toString();
+    }
+
+    private static String extractTargetName(JsonValue addressJson) {
+		JsonValue targetRefJson = addressJson.asObject().get("targetRef");
+		if (targetRefJson == null) return null;
+        return targetRefJson.asObject().get("name").toString();
     }
 
     private static Integer extractPort(JsonValue subsetJson) {
@@ -306,13 +333,29 @@ class KubernetesClient {
      * </li>
      * </ol>
      */
-    private List<Endpoint> enrichWithPublicAddresses(List<Endpoint> endpoints) {
+    private List<Endpoint> enrichWithPublicAddresses(List<Endpoint> endpoints, boolean matchNames, String lbLabel, String lbLabelValue) {
         try {
+
+            // Problem: 'services' may end up containing the load-balancing service if there is only one member
+            // (pod) in the cluster, and this means we can return the load-balancing service public IP for one
+            // member in place of the actual member's public IP.
+            //
+            // Fix: by default matchNames is true, which means that 'services' will only contain those services
+            // with only 1 endpoint, and a name that matches the name of the endpoint. Assuming that member
+            // services are named with the same name as their member pods, this filters out the load-balancing
+            // service.
+            // When matchNames is false, it is possible to use lbLabel instead to filter out endpoints that
+            // don't match a certain label, usually the label that is used by the load-balancer to identify
+            // the load-balanced pods. This allows for finer control of the load-balancer exclusion.
+
             String endpointsUrl = String.format("%s/api/v1/namespaces/%s/endpoints", kubernetesMaster, namespace);
+            if (lbLabel != null && !lbLabel.isEmpty() && lbLabelValue != null && !lbLabelValue.isEmpty()) {
+                endpointsUrl += String.format("?labelSelector=%s!=%s", lbLabel, lbLabelValue);
+            }
             JsonObject endpointsJson = callGet(endpointsUrl);
 
             List<EndpointAddress> privateAddresses = privateAddresses(endpoints);
-            Map<EndpointAddress, String> services = extractServices(endpointsJson, privateAddresses);
+            Map<EndpointAddress, String> services = extractServices(endpointsJson, privateAddresses, matchNames);
             Map<EndpointAddress, String> nodes = extractNodes(endpointsJson, privateAddresses);
 
             Map<EndpointAddress, String> publicIps = new HashMap<EndpointAddress, String>();
@@ -368,12 +411,15 @@ class KubernetesClient {
     }
 
     private static Map<EndpointAddress, String> extractServices(JsonObject endpointsListJson,
-                                                                List<EndpointAddress> privateAddresses) {
+                                                                List<EndpointAddress> privateAddresses,
+                                                                boolean matchNames) {
         Map<EndpointAddress, String> result = new HashMap<EndpointAddress, String>();
         Set<EndpointAddress> left = new HashSet<EndpointAddress>(privateAddresses);
         for (JsonValue item : toJsonArray(endpointsListJson.get("items"))) {
             String service = toString(item.asObject().get("metadata").asObject().get("name"));
-            List<Endpoint> endpoints = parseEndpoints(item);
+            List<Endpoint> endpoints = parseEndpoints(item, matchNames);
+
+
             // Service must point to exactly one endpoint address, otherwise the public IP would be ambiguous.
             if (endpoints.size() == 1) {
                 EndpointAddress address = endpoints.get(0).getPrivateAddress();

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesConfig.java
@@ -29,22 +29,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-import static com.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_API_RETIRES;
-import static com.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_API_TOKEN;
-import static com.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_CA_CERTIFICATE;
-import static com.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_MASTER_URL;
-import static com.hazelcast.kubernetes.KubernetesProperties.KUBERNETES_SYSTEM_PREFIX;
-import static com.hazelcast.kubernetes.KubernetesProperties.NAMESPACE;
-import static com.hazelcast.kubernetes.KubernetesProperties.POD_LABEL_NAME;
-import static com.hazelcast.kubernetes.KubernetesProperties.POD_LABEL_VALUE;
-import static com.hazelcast.kubernetes.KubernetesProperties.RESOLVE_NOT_READY_ADDRESSES;
-import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_DNS;
-import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_DNS_TIMEOUT;
-import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_NAME;
-import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_LABEL_VALUE;
-import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_NAME;
-import static com.hazelcast.kubernetes.KubernetesProperties.SERVICE_PORT;
-import static com.hazelcast.kubernetes.KubernetesProperties.USE_NODE_NAME_AS_EXTERNAL_ADDRESS;
+import static com.hazelcast.kubernetes.KubernetesProperties.*;
 
 /**
  * Responsible for fetching, parsing, and validating Hazelcast Kubernetes Discovery Strategy input properties.
@@ -66,6 +51,9 @@ final class KubernetesConfig {
     private final String namespace;
     private final String podLabelName;
     private final String podLabelValue;
+    private final boolean matchServicePodNames;
+    private final String lbLabelName;
+    private final String lbLabelValue;
     private final boolean resolveNotReadyAddresses;
     private final boolean useNodeNameAsExternalAddress;
     private final int kubernetesApiRetries;
@@ -85,6 +73,9 @@ final class KubernetesConfig {
         this.serviceLabelValue = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, SERVICE_LABEL_VALUE, "true");
         this.podLabelName = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, POD_LABEL_NAME);
         this.podLabelValue = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, POD_LABEL_VALUE);
+        this.matchServicePodNames = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, MATCH_SERVICE_POD_NAMES, true);
+        this.lbLabelName = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, LB_LABEL_NAME);
+        this.lbLabelValue = getOrNull(properties, KUBERNETES_SYSTEM_PREFIX, LB_LABEL_VALUE);
         this.resolveNotReadyAddresses = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, RESOLVE_NOT_READY_ADDRESSES, true);
         this.useNodeNameAsExternalAddress
                 = getOrDefault(properties, KUBERNETES_SYSTEM_PREFIX, USE_NODE_NAME_AS_EXTERNAL_ADDRESS, false);
@@ -295,6 +286,16 @@ final class KubernetesConfig {
         return podLabelValue;
     }
 
+    public boolean getMatchServicePodNames() { return matchServicePodNames; }
+
+    public String getLbLabelName() {
+        return lbLabelName;
+    }
+
+    public String getLbLabelValue() {
+        return lbLabelValue;
+    }
+
     boolean isResolveNotReadyAddresses() {
         return resolveNotReadyAddresses;
     }
@@ -335,6 +336,9 @@ final class KubernetesConfig {
                 + "namespace: " + namespace + ", "
                 + "pod-label: " + podLabelName + ", "
                 + "pod-label-value: " + podLabelValue + ", "
+				+ "match-service-pod-names: " + matchServicePodNames + ", "
+                + "lb-label: " + lbLabelName + ", "
+                + "lb-label-value: " + lbLabelValue + ", "
                 + "resolve-not-ready-addresses: " + resolveNotReadyAddresses + ", "
                 + "use-node-name-as-external-address: " + useNodeNameAsExternalAddress + ", "
                 + "kubernetes-api-retries: " + kubernetesApiRetries + ", "

--- a/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
+++ b/src/main/java/com/hazelcast/kubernetes/KubernetesProperties.java
@@ -97,6 +97,23 @@ public final class KubernetesProperties {
     public static final PropertyDefinition POD_LABEL_VALUE = property("pod-label-value", STRING);
 
     /**
+     * <p>Configuration key: <code>match-service-pod-names</code></p>
+     * Whether to match the service and pod names.
+     */
+    public static final PropertyDefinition MATCH_SERVICE_POD_NAMES = property("match-service-pod-names", BOOLEAN);
+
+    /**
+     * <p>Configuration key: <code>lb-label-name</code></p>
+     * Defines the load balancer label name.
+     */
+    public static final PropertyDefinition LB_LABEL_NAME = property("lb-label-name", STRING);
+    /**
+     * <p>Configuration key: <code>lb-label-value</code></p>
+     * Defines the load balancer label value.
+     */
+    public static final PropertyDefinition LB_LABEL_VALUE = property("lb-label-value", STRING);
+
+    /**
      * <p>Configuration key: <code>resolve-not-ready-addresses</code></p>
      * Defines if not ready addresses should be evaluated to be discovered on startup.
      */


### PR DESCRIPTION
When following [this guide](https://guides.hazelcast.org/kubernetes-external-client/) to get the .NET client to connect to a Kubernetes-hosted cluster, in *Smart Client* mode, I came onto an issue when the cluster is composed of only one member. At that point, there are two services:
* `hz-hazelcast` is the "discovery" service - which at that moment points to only 1 address (of pod `hz-hazelcast-0`)
* `hz-hazelcast-0` is the service corresponding to the `hz-hazelcast-0` pod 

Because the "discovery" service points to only 1 address, it is considered as a "member" service *and* its public IP can be returned as the public IP of service `hz-hazelcast-0`, or not, depending on the order of the services, and this lead to great confusion at the client side. Especially if for some reason the cluster keeps toggling between 1 and 2 members, in which case the client ends up receiving totally confusing data about members.

This PR is totally experimental, but it's what I had to implement in order to keep testing the .NET client with some success. What it does is:
* add a `match-service-pod-names` configuration property which is `true` by default and gets the `KubernetesClient` to match the service name with the pod name (e.g. `hz-hazelcast` would not match `hz-hazelcast-0` and therefore the "discovery" service would be discarded)
* add a `lb-label-name` and `lb-label-value` pair of configuration properties (empty by default) which can be used to specify services which need to be *excluded* when looking for members - to be used when the names-matching is not enough and we want to be even more specific

Now, with the default configuration (`match-service-pod-names` being `true`) the .NET client receives correct data about members even in the case when the cluster toggles between 1 and more members erratically.

This PR is not meant to be merged "as is". I am creating it to explain the issue and the fix that I am using, but the actual proper fix may be totally different. I am certainly no k8s expert ;)