### PR TITLE
Link to Hazelcast 5.0 on Kubernetes documentation fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 #### **DEPRECATED:** `hazelcast-kubernetes` plugin has been merged with [`hazelcast`](https://github.com/hazelcast/hazelcast)!
-Since version `5.0` `hazelcast` includes `hazelcast-kubernetes` and does not require additional dependency. For details about running Hazelcast on Kubernetes consider the [documentation](https://docs.hazelcast.com/hazelcast/5.0-SNAPSHOT/deploy/deploying-in-kubernetes.html).
+Since version `5.0` `hazelcast` includes `hazelcast-kubernetes` and does not require additional dependency. For details about running Hazelcast on Kubernetes consider the [documentation](https://docs.hazelcast.com/hazelcast/5.0/deploy/deploying-in-kubernetes.html).
 
 # Hazelcast Discovery Plugin for Kubernetes
 


### PR DESCRIPTION
Fix for 404 error for running Hazelcast on Kubernetes documentation link.